### PR TITLE
fix(release): use tomllib.load() to read version after bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           uv version --bump ${{ steps.bump.outputs.type }}
           uv lock
-          NEW=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read())['project']['version'])")
+          NEW=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "new=$NEW" >> $GITHUB_OUTPUT
 
       - name: Commit, tag, and push


### PR DESCRIPTION
## Summary

Fixes the release workflow failing on the version-read step. `tomllib.loads()` expects a `str` but the file was opened in binary mode (`'rb'`), causing a `TypeError`. Replaced with `tomllib.load()` which accepts a binary file object directly.

This also re-triggers the `v1.0.0` release that failed to complete on the previous merge.

## Changes

- Fixed `tomllib.loads()` → `tomllib.load()` in `release.yml`

## Commit type

- [x] `fix` — bug fix

## Release

- [x] `bump:major` applied

## Review checklist

- [x] Code is clear and follows project conventions
- [x] No secrets or credentials introduced
- [x] CI is green (`lint`, `type-check`, `run-pytest`)
- [x] Correct bump label applied (or confirmed not needed)