### PR TITLE
fix(release): push tag explicitly instead of --follow-tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,8 @@ jobs:
           git add pyproject.toml uv.lock
           git commit -m "chore(release): bump version to v${{ steps.version.outputs.new }}"
           git tag "v${{ steps.version.outputs.new }}"
-          git push origin main --follow-tags
+          git push origin main
+          git push origin "v${{ steps.version.outputs.new }}"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary

`--follow-tags` only pushes annotated tags, but the release script creates a lightweight tag with `git tag`, so the tag was never pushed to the remote — causing `gh release create` to fail. Replaced with an explicit `git push origin <tag>` after pushing main.

## Changes

- Split `git push origin main --follow-tags` into `git push origin main` + `git push origin "v<version>"`

## Commit type

- [x] `fix` — bug fix

## Release

- [ ] `bump:patch` applied — backwards-compatible bug fix
- [ ] `bump:minor` applied — new backwards-compatible functionality
- [ ] `bump:major` applied — breaking change (`!` in commit message)
- [x] No release needed

## Review checklist

- [x] Code is clear and follows project conventions
- [x] No secrets or credentials introduced
- [x] CI is green (`lint`, `type-check`, `run-pytest`)
- [x] Correct bump label applied (or confirmed not needed)