### PR TITLE
fix(docs): switch Pages deployment to GitHub Actions source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,10 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,7 +29,21 @@ jobs:
 
       - run: uv sync --group docs
 
-      - run: uv run mkdocs gh-deploy --force
+      - run: uv run mkdocs build
         env:
           DOCS_REPO_URL: https://github.com/${{ github.repository }}
           DOCS_REPO_NAME: ${{ github.repository }}
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: ANT-AI
-repo_url: !ENV [DOCS_REPO_URL, "https://gitlab.com/<org>/ant-ai"]
-repo_name: !ENV [DOCS_REPO_NAME, "<org>/ant-ai"]
+repo_url: !ENV [DOCS_REPO_URL, "https://github.com/idea-idsia/ant-ai"]
+repo_name: !ENV [DOCS_REPO_NAME, "idea-idsia/ant-ai"]
 
 docs_dir: docs
 extra_css:


### PR DESCRIPTION
## Summary
- Replace `mkdocs gh-deploy` (branch-based) with a two-job workflow using `actions/upload-pages-artifact` and `actions/deploy-pages`
- Update permissions to `pages: write` + `id-token: write` as required by the GitHub Pages API
- Compatible with the "GitHub Actions" source setting in repo Pages settings

## Test plan
- [ ] Merge and confirm the `Deploy docs` workflow runs successfully on GitHub Actions
- [ ] Verify the site is live at https://idea-idsia.github.io/ant-ai/