### PR TITLE
chore(vscode): add workspace settings and extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "astral-sh.ty",
+        "njpwerner.autodocstring",
+        "esbenp.prettier-vscode",
+        "samuelcolvin.jinjahtml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,45 @@
+{
+    "editor.formatOnSave": true,
+    "python.terminal.useEnvFile": true,
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+
+    "[yaml]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+
+    "[toml]": {
+        "editor.defaultFormatter": "tamasfe.even-better-toml"
+    },
+
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+
+    "[jsonl]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+
+    "ruff.configuration": "ruff.toml",
+
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit",
+        "source.organizeImports": "explicit",
+        "source.fixAll.ruff": "explicit"
+    },
+
+    "python.languageServer": "None",
+
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "autoDocstring.docstringFormat": "google-notypes",
+
+    "python.testing.pytestArgs": ["tests"],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
## Summary

Adds VSCode workspace configuration files to the repository. These provide consistent editor settings and recommend the extensions used in this project, improving the onboarding experience for contributors.

## Changes

- Added `.vscode/settings.json` — configures format-on-save with Ruff for Python, Prettier for YAML/JSON/TOML, auto-import organisation, and pytest integration
- Added `.vscode/extensions.json` — recommends extensions: Python, Ruff, ty, autoDocstring, Prettier, and Jinja HTML

## Related

Closes #

## Commit type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code restructuring, no behaviour change
- [ ] `test` — adding or correcting tests
- [x] `chore` — maintenance, deps, config, tooling
- [ ] `perf` — performance improvement
- [ ] `ci` — CI/CD pipeline changes

## Release

- [ ] `bump:patch` applied — backwards-compatible bug fix
- [ ] `bump:minor` applied — new backwards-compatible functionality
- [ ] `bump:major` applied — breaking change (`!` in commit message)
- [x] No release needed

## Review checklist

- [x] Code is clear and follows project conventions
- [x] No secrets or credentials introduced
- [x] New behaviour is covered by tests; existing tests pass
- [x] Public API changes are reflected in docstrings and docs
- [x] CI is green (`lint`, `type-check`, `run-pytest`)
- [x] Correct bump label applied (or confirmed not needed)