### PR TITLE
ci(coverage): replace GitLab badge with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
 
       - run: uv sync --all-packages --all-groups --all-extras
 
-      - run: uv run pytest -m "not vllm and not external" --cov --cov-report=term --junitxml=report.xml
+      - run: uv run pytest -m "not vllm and not external" --cov --cov-report=term --cov-report=xml --junitxml=report.xml
+
+      - uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Python](https://img.shields.io/badge/python-3.14%2B-4584b6?logo=python&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue?logo=MIT&logoColor=white-lightgrey)
-[![Coverage main](https://gitlab-core.supsi.ch/dti-idsia/intsys/ant-ai/badges/main/coverage.svg)](https://gitlab-core.supsi.ch/dti-idsia/intsys/ant-ai/-/commits/main)
+[![Coverage](https://codecov.io/gh/idea-idsia/ant-ai/branch/main/graph/badge.svg)](https://codecov.io/gh/idea-idsia/ant-ai)
 [![Docs](https://img.shields.io/badge/docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://ant-ai-27f99d.pages-core.supsi.ch)
 
 **A lightweight Python framework for building tool-driven AI agents and multi-agent systems.**


### PR DESCRIPTION
## Summary

- Adds `--cov-report=xml` to the `run-pytest` job so a `coverage.xml` file is generated
- Uploads coverage to Codecov via `codecov/codecov-action@v5`
- Replaces the broken GitLab coverage badge in README with the Codecov badge for `idea-idsia/ant-ai`

## Test plan

- [x] CI passes on this PR (lint, type-check, run-pytest)
- [ ] Codecov receives the coverage report and the badge renders correctly after merge to `main`