### PR TITLE
ci(coverage): add CODECOV_TOKEN for protected branch upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: actions/upload-artifact@v7
         if: always()


### PR DESCRIPTION
## Summary

- Passes `CODECOV_TOKEN` secret to `codecov/codecov-action` so uploads succeed when `main` is a protected branch

## Before merging

Add the `CODECOV_TOKEN` secret to the repo:
1. Codecov → `ant-ai` repo → **Settings** → copy the Repository Upload Token
2. GitHub repo → **Settings → Secrets and variables → Actions → New repository secret** → name: `CODECOV_TOKEN`