### PR TITLE
ci: integrate Codecov coverage and test analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,23 @@ jobs:
 
             - run: uv sync --all-packages --all-groups --all-extras
 
-            - run: uv run pytest -m "not vllm and not external" --cov --cov-report=term --cov-report=xml
+            - run: uv run pytest -m "not vllm and not external" --cov --cov-report=term --cov-report=xml --junitxml=junit.xml
 
             - uses: codecov/codecov-action@v5
               with:
                   files: coverage.xml
                   token: ${{ secrets.CODECOV_TOKEN }}
 
+            - uses: codecov/test-results-action@v1
+              if: ${{ !cancelled() }}
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+
             - uses: actions/upload-artifact@v7
               if: always()
               with:
                   name: pytest-results
-                  path: report.xml
+                  path: junit.xml
 
     run-pytest-postgres:
         runs-on: ubuntu-latest
@@ -91,6 +96,11 @@ jobs:
             - run: uv run pytest -m "postgres" --cov --cov-report=term --junitxml=report-postgres.xml
               env:
                   POSTGRES_TEST_URL: "postgresql+asyncpg://postgres:postgres@localhost:5432/tasks"
+
+            - uses: codecov/test-results-action@v1
+              if: ${{ !cancelled() }}
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
 
             - uses: actions/upload-artifact@v7
               if: always()


### PR DESCRIPTION
## Summary

- Replaces GitLab CI badge with Codecov coverage badge
- Adds `CODECOV_TOKEN` secret usage to coverage upload for protected branch support
- Adds `codecov/test-results-action@v1` to both pytest jobs (`run-pytest` and `run-pytest-postgres`) to populate Codecov Test Analytics dashboard
- Fixes pre-existing bug: `run-pytest` was uploading `report.xml` as an artifact but never generating it — now generates and uploads `junit.xml`

## Test plan

- [x] CI runs on this PR and coverage uploads successfully to Codecov
- [x] Test results appear in Codecov Test Analytics dashboard after CI completes