### PR TITLE
ci(test-analytics): switch to codecov-action@v5 with report_type: test_results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,11 @@ jobs:
                   files: coverage.xml
                   token: ${{ secrets.CODECOV_TOKEN }}
 
-            - uses: codecov/test-results-action@v1
+            - uses: codecov/codecov-action@v5
               if: ${{ !cancelled() }}
               with:
+                  files: junit.xml
+                  report_type: test_results
                   token: ${{ secrets.CODECOV_TOKEN }}
 
             - uses: actions/upload-artifact@v7
@@ -97,9 +99,11 @@ jobs:
               env:
                   POSTGRES_TEST_URL: "postgresql+asyncpg://postgres:postgres@localhost:5432/tasks"
 
-            - uses: codecov/test-results-action@v1
+            - uses: codecov/codecov-action@v5
               if: ${{ !cancelled() }}
               with:
+                  files: report-postgres.xml
+                  report_type: test_results
                   token: ${{ secrets.CODECOV_TOKEN }}
 
             - uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- `codecov/test-results-action@v1` is deprecated — the CI logs explicitly warned to migrate
- Replaces it with `codecov/codecov-action@v5` using `report_type: test_results` in both pytest jobs
- Explicitly passes the JUnit XML file path (`junit.xml` / `report-postgres.xml`) to avoid auto-discovery issues

## Test plan

- [ ] CI passes and test results appear in the Codecov Test Analytics dashboard after this merges to main