### PR TITLE
docs: update README, docs copy, and pyproject.toml metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Python](https://img.shields.io/badge/python-3.14%2B-4584b6?logo=python&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue?logo=MIT&logoColor=white-lightgrey)
 [![Coverage](https://codecov.io/gh/idea-idsia/ant-ai/branch/main/graph/badge.svg)](https://codecov.io/gh/idea-idsia/ant-ai)
-[![Docs](https://img.shields.io/badge/docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://ant-ai-27f99d.pages-core.supsi.ch)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://idea-idsia.github.io/ant-ai/)
 
 **A lightweight Python framework for building tool-driven AI agents and multi-agent systems.**
 
@@ -16,17 +16,17 @@
 
 ---
 
-ANT AI provides a composable set of primitives for building production-ready AI agents: a ReAct reasoning loop, a flexible tool system with MCP support, a graph-based workflow engine, and first-class agent-to-agent (A2A) communication via the [A2A protocol](https://github.com/a2aproject/A2A).
+`ant-ai` is a lightweight Python framework for building multi-agent systems: graph-based workflow orchestration, first-class agent-to-agent (A2A) communication via the [A2A protocol](https://github.com/a2aproject/A2A), MCP tool integration, lifecycle hooks for guardrails, and built-in observability — all on top of an LLM-agnostic core.
 
-## Features
+## Why ANT AI
 
-- **ReAct agent** — built-in Reason→Act loop with streaming, structured output, and configurable retry logic
-- **Flexible tools** — define tools as decorated functions, class namespaces, or load them directly from any [MCP](https://modelcontextprotocol.io/) server
-- **Workflow engine** — graph-based orchestration with static and conditional edges to sequence agent behaviour predictably
-- **Multi-agent colony** — wire agents together with the A2A protocol; each agent becomes a callable tool to its peers
-- **LLM-agnostic** — ships with [LiteLLM](https://github.com/BerriAI/litellm) and native OpenAI backends; any `ChatLLM`-conforming implementation works
-- **Observability** — structured lifecycle events with [Langfuse](https://langfuse.com/), OpenTelemetry, and log sinks
-- **Lifecycle hooks** — intercept and control every LLM call: pass, block, retry, or substitute results; ships with a [GuardrailsAI](https://www.guardrailsai.com/) adapter
+**Multi-agent by design.** Agents communicate and delegate natively via the [A2A protocol](https://github.com/a2aproject/A2A) — build systems that grow without rewrites.
+
+**No lock-in.** Swap LLMs, tools, or observability backends in one line. Your logic stays untouched.
+
+**Structured, not scripted.** Model complex behavior as graphs. Know exactly what runs, when, and why.
+
+**Production-ready out of the box.** Hooks, guardrails, and full observability via [Langfuse](https://langfuse.com/) and OpenTelemetry — without extra setup.
 
 ## Installation
 
@@ -39,7 +39,7 @@ uv add ant-ai
 Or clone and sync for local development:
 
 ```sh
-git clone <repo-url>
+git clone https://github.com/idea-idsia/ant-ai
 cd ant-ai
 uv sync --all-extras
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ title: Docs
 
     ***
 
-    Get ant_ai installed using uv or from source.
+    Get up and running with `uv` in one command.
 
     [:octicons-arrow-right-24: Get started](install/index.md)
 
@@ -18,7 +18,7 @@ title: Docs
 
     ***
 
-    Build an agent with tools and stream a response.
+    Create your first agent, give it tools, and stream its responses.
 
     [:octicons-arrow-right-24: Build an agent](single-agent/index.md)
 
@@ -26,7 +26,7 @@ title: Docs
 
     ***
 
-    Connect agents in a Colony using the A2A protocol.
+    Wire agents together into a Colony that collaborates via A2A.
 
     [:octicons-arrow-right-24: Build a Colony](multi-agent/index.md)
 
@@ -34,7 +34,7 @@ title: Docs
 
     ***
 
-    Understand how events flow through the system end-to-end.
+    See how agents, workflows, and events fit together end-to-end.
 
     [:octicons-arrow-right-24: Read more](architecture/index.md)
 

--- a/docs/docs/install/index.md
+++ b/docs/docs/install/index.md
@@ -4,20 +4,20 @@ title: Installation
 
 # Installation
 
-ant_ai requires **Python 3.13 or later**. [uv](https://docs.astral.sh/uv/) is the recommended package manager.
+`ant-ai` requires **Python 3.14 or later**. [uv](https://docs.astral.sh/uv/) is the recommended package manager.
 
 ## From PyPI
 
 ```bash
-uv add ant_ai
+uv add ant-ai
 ```
 
 ### Optional extras
 
-ant_ai ships an optional extra for the OpenAI client integration:
+`ant-ai` ships an optional extra for the OpenAI client integration:
 
 ```bash
-uv add "ant_ai[openai]"
+uv add "ant-ai[openai]"
 ```
 
 ## From the repository
@@ -25,7 +25,7 @@ uv add "ant_ai[openai]"
 To install directly from source, point `uv` at the Git repository:
 
 ```bash
-uv add "ant_ai @ git+https://github.com/TBD/ant_ai"
+uv add "ant-ai @ git+https://github.com/idea-idsia/ant-ai"
 ```
 
 ## Verifying the installation

--- a/docs/docs/single-agent/index.md
+++ b/docs/docs/single-agent/index.md
@@ -4,7 +4,7 @@ title: Single-agent
 
 # Single-agent setup
 
-A single ant_ai agent pairs an LLM with a set of tools and, optionally, a Workflow that structures how it processes a request.
+A single `ant-ai` agent pairs an LLM with tools and, optionally, a Workflow that controls how it moves through a task.
 
 ## Creating an agent
 
@@ -99,7 +99,7 @@ agent = Agent(..., tools=tools)
 
 ## Streaming a response
 
-[`Agent.stream()`][ant_ai.agent.agent.Agent.stream] runs the ReAct loop — LLM call → tool calls → tool results — until a final answer is produced. It yields [`Event`][ant_ai.core.events.Event] objects throughout.
+[`Agent.stream()`][ant_ai.agent.agent.Agent.stream] drives the agent until it produces a final answer, yielding [`Event`][ant_ai.core.events.Event] objects at each step — LLM output, tool calls, tool results, and completion.
 
 ```python
 import asyncio

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ title: Home
   <img alt="ANT AI" src="assets/ant_h_white.png" class="only-dark" style="display: block; margin: 0 auto;" width="220">
 </div>
 
-`ant-ai` is a Python framework for building LLM-powered agents and multi-agent systems.
+`ant-ai` is a lightweight Python framework for building multi-agent AI systems — from a single agent to a full colony of collaborating peers.
 
 ## Quick start
 
@@ -47,7 +47,7 @@ asyncio.run(main())
 
 ## Next steps
 
-- **[Install](docs/install/index.md)** — get ant_ai installed in your project.
+- **[Install](docs/install/index.md)** — get `ant-ai` installed in your project.
 - **[Single-agent guide](docs/single-agent/index.md)** — build an agent with tools.
 - **[Multi-agent guide](docs/multi-agent/index.md)** — connect agents in a Colony.
 - **[Architecture](docs/architecture/index.md)** — how events flow through the system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 [project]
 name = "ant-ai"
 version = "1.0.0"
-description = "ANT AI"
+description = "A lightweight Python framework for building multi-agent AI systems"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -63,6 +63,11 @@ docs = [
     "mkdocs-section-index>=0.3.12",
     "mkdocstrings[python]>=1.0.4",
 ]
+
+[project.urls]
+Homepage = "https://idea-idsia.github.io/ant-ai/"
+Documentation = "https://idea-idsia.github.io/ant-ai/"
+Repository = "https://github.com/idea-idsia/ant-ai"
 
 [tool.uv]
 exclude-newer = "P2D" # Wait for the package to be up for at least 2 days before updating to it.


### PR DESCRIPTION
## Summary

- Rewrites README intro and feature section for clarity and better positioning
- Fixes docs badge URL to point to GitHub Pages instead of old Cloudflare URL
- Corrects package name references throughout docs (`ant_ai` → `ant-ai`)
- Updates `pyproject.toml` description and adds `[project.urls]` (Homepage, Docs, Repository)

## Test plan

- [ ] Verify docs site renders correctly after merge
- [ ] Verify PyPI metadata shows updated description and URLs after next release