### PR TITLE
fix: readme image URLs, release push, and publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Upload Python Package
 on:
     release:
         types: [published]
-    workflow_dispatch:
 
 permissions:
     contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
                   git add pyproject.toml uv.lock
                   git commit -m "chore(release): bump version to v${{ steps.version.outputs.new }}"
                   git tag "v${{ steps.version.outputs.new }}"
-                  git push origin main
+                  git push origin HEAD:main
                   git push origin "v${{ steps.version.outputs.new }}"
 
             - name: Create GitHub Release

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/ant_h_white.png">
-  <img alt="ANT AI" src="docs/assets/ant_h_dark.png" height="100">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/idea-idsia/ant-ai/main/docs/assets/ant_h_white.png">
+  <img alt="ANT AI" src="https://raw.githubusercontent.com/idea-idsia/ant-ai/main/docs/assets/ant_h_dark.png" height="100">
 </picture>
 
 ![Python](https://img.shields.io/badge/python-3.14%2B-4584b6?logo=python&logoColor=white)


### PR DESCRIPTION
## Summary

- Fix README image paths to use absolute `raw.githubusercontent.com` URLs so the logo renders on PyPI
- Fix `release.yml`: use `HEAD:main` instead of `main` to avoid detached HEAD push failure
- Fix `publish.yml`: remove `workflow_dispatch` trigger — it defaults to `main` ref which is rejected by the PyPI environment protection (tags only, `v*`)

## Test plan

- [ ] Release workflow completes without push error
- [ ] Publish workflow triggers from the `v*` tag and deploys to PyPI successfully
- [ ] Logo visible on PyPI project page