### PR TITLE
ci(release): fix publish pipeline with tag-based trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,13 @@
-name: Upload Python Package
+name: Publish
 
 on:
-    release:
-        types: [published]
-
-permissions:
-    contents: read
+    push:
+        tags:
+            - "v*"
 
 jobs:
-    release-build:
+    build:
         runs-on: ubuntu-latest
-
         steps:
             - uses: actions/checkout@v6
 
@@ -18,34 +15,41 @@ jobs:
               with:
                   enable-cache: true
 
-            - name: Build release distributions
+            - name: Build distributions
               run: uv build
 
-            - name: Upload distributions
-              uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@v4
               with:
-                  name: release-dists
+                  name: dist
                   path: dist/
 
-    pypi-publish:
+    publish:
         runs-on: ubuntu-latest
-        needs:
-            - release-build
+        needs: build
         permissions:
+            contents: write
             id-token: write
 
         environment:
             name: pypi
-            url: https://pypi.org/project/ant-ai/${{ github.event.release.tag_name }}
+            url: https://pypi.org/project/ant-ai/${{ github.ref_name }}
 
         steps:
-            - name: Retrieve release distributions
-              uses: actions/download-artifact@v8
+            - uses: actions/download-artifact@v4
               with:
-                  name: release-dists
+                  name: dist
                   path: dist/
 
-            - name: Publish release distributions to PyPI
+            - name: Publish to PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   packages-dir: dist/
+
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh release create "${{ github.ref_name }}" \
+                    --repo "${{ github.repository }}" \
+                    --title "${{ github.ref_name }}" \
+                    --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
                   NEW=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
                   echo "new=$NEW" >> $GITHUB_OUTPUT
 
-            - name: Commit, tag, and push
+            - name: Commit and push tag
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -56,11 +56,3 @@ jobs:
                   git tag "v${{ steps.version.outputs.new }}"
                   git push origin HEAD:main
                   git push origin "v${{ steps.version.outputs.new }}"
-
-            - name: Create GitHub Release
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  gh release create "v${{ steps.version.outputs.new }}" \
-                    --title "v${{ steps.version.outputs.new }}" \
-                    --generate-notes


### PR DESCRIPTION
## Summary

- `release.yml` now only bumps the version, commits, and pushes the tag — nothing else
- `publish.yml` now triggers on `push: tags: v*` instead of `release: published`
  - Runs in tag context → satisfies PyPI environment protection (`v*` tags only)
  - Fixes the root cause: `GITHUB_TOKEN`-created releases do not trigger downstream workflows
  - OIDC trusted publishing works without any PAT

## Test plan

- [ ] Merge triggers `release.yml` → version bumped, tag pushed
- [ ] Tag push triggers `publish.yml` → builds and publishes to PyPI
- [ ] GitHub Release created automatically after PyPI publish