### PR TITLE
ci(release): use RELEASE_PAT to trigger publish on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.RELEASE_PAT }}
 
             - uses: astral-sh/setup-uv@v8.1.0
               with:


### PR DESCRIPTION
Switch checkout token from GITHUB_TOKEN to RELEASE_PAT. GITHUB_TOKEN pushes cannot trigger downstream workflows (GitHub constraint). With a PAT, the tag push from release.yml will correctly fire publish.yml.