### PR TITLE
fix(cd): install viz extra so graphviz is available during docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
                   python-version: "3.14"
                   enable-cache: true
 
-            - run: uv sync --group docs
+            - run: uv sync --group docs --extra viz
 
             - run: uv run mkdocs build
               env:


### PR DESCRIPTION
## Summary
- Adds `--extra viz` to the `uv sync` call in the docs workflow so the `graphviz` package is installed during the docs build
- CI workflows are unaffected — they already use `--all-extras`