### PR TITLE
fix(workflow): trace conditional edge routers as Langfuse spans

### DIFF
--- a/src/ant_ai/workflow/workflow.py
+++ b/src/ant_ai/workflow/workflow.py
@@ -130,16 +130,21 @@ class Workflow(BaseModel):
         state: State,
         ctx: InvocationContext | None,
         current: str,
+        run_step: int = 0,
     ) -> str:
         if current in self.conditional_edges:
-            nxt: str = await _maybe_await(
-                self.conditional_edges[current](agent, state, ctx)
+            router = self.conditional_edges[current]
+            router_name = getattr(router, "__name__", f"{current}_router")
+            await obs.event(
+                "node.start", node=router_name, run_step=run_step, input=current
             )
-            await obs.event("node.edge.router", src=current, dst=nxt)
+            nxt: str = await _maybe_await(router(agent, state, ctx))
             if not isinstance(nxt, str) or not nxt:
                 raise RuntimeError("Router must return a non-empty str.")
             if nxt not in (START, END) and nxt not in self.nodes:
                 raise RuntimeError(f"Unknown node '{nxt}'.")
+            await obs.event("node.edge.router", src=current, dst=nxt)
+            await obs.event("node.end", node=router_name, run_step=run_step, output=nxt)
             return nxt
 
         if current in self.edges:
@@ -269,7 +274,7 @@ class Workflow(BaseModel):
                     async for ev in self._run_node(agent, run, ctx, current):
                         yield ev
 
-                current = await self._next(agent, run.state, ctx, current)
+                current = await self._next(agent, run.state, ctx, current, run.step)
 
     async def ainvoke(
         self,

--- a/tests/integration/observer/test_langfuse_integration.py
+++ b/tests/integration/observer/test_langfuse_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import time
 
@@ -130,6 +131,28 @@ def _failing_workflow() -> Workflow:
     w.add_node("failing_node", boom)
     w.add_edge(START, "failing_node")
     w.add_edge("failing_node", END)
+    return w
+
+
+def _conditional_workflow() -> Workflow:
+    w = Workflow()
+
+    async def noop(agent, state, ctx):
+        async def _gen():
+            await asyncio.sleep(0.05)
+            if False:
+                yield
+
+        return _gen()
+
+    async def route_to_node_b(agent, state, ctx):
+        return "node_b"
+
+    w.add_node("node_a", noop)
+    w.add_node("node_b", noop)
+    w.add_edge(START, "node_a")
+    w.add_conditional_edge("node_a", route_to_node_b)
+    w.add_edge("node_b", END)
     return w
 
 
@@ -345,6 +368,39 @@ async def test_tool_span_input_is_stored():
     assert tool_obs[0].input is not None, "tool observation has no input"
     assert tool_obs[0].output is not None, "tool observation has no output"
     assert trace.output == tool_output
+
+
+@pytest.mark.integration
+@pytest.mark.external
+@pytest.mark.langfuse
+async def test_conditional_router_appears_as_span():
+    lf = _langfuse_client()
+    sink = LangfuseSink(langfuse=lf)
+    obs.configure(sink)
+
+    agent = _DummyAgent(name="integration_agent")
+    ctx = InvocationContext(session_id="integ-test-router")
+    workflow = _conditional_workflow()
+
+    await workflow.ainvoke(agent, ctx=ctx, state=_state_with_message())
+    _flush_and_shutdown(lf)
+
+    assert sink.last_trace_id is not None
+
+    # Expect: agent root + node_a + route_to_node_b router + node_b = 4 observations
+    trace = _get_trace(lf, sink.last_trace_id, min_obs=4)
+    obs_names = {o.name for o in trace.observations}
+    assert "route_to_node_b" in obs_names, (
+        f"Expected router span 'route_to_node_b' in trace, got {obs_names}"
+    )
+
+    router_obs = next(o for o in trace.observations if o.name == "route_to_node_b")
+    assert str(router_obs.input) == "node_a", (
+        f"Expected router input 'node_a', got {router_obs.input!r}"
+    )
+    assert str(router_obs.output) == "node_b", (
+        f"Expected router output 'node_b', got {router_obs.output!r}"
+    )
 
 
 @pytest.mark.integration

--- a/tests/unit/observer/test_langfuse.py
+++ b/tests/unit/observer/test_langfuse.py
@@ -310,6 +310,30 @@ async def test_generic_exception_updates_current_observation_only():
 
 
 @pytest.mark.unit
+async def test_router_node_creates_span_with_input_and_output():
+    root = make_observation("root")
+    node = make_observation("node")
+    router_obs = make_observation("router")
+    lf = make_langfuse_mock(root, node, router_obs)
+    sink = LangfuseSink(langfuse=lf)
+    obs.configure(sink)
+
+    await obs.event("workflow.start", session_id="s1", agent_name="a")
+    await obs.event("node.start", node="planner", run_step=1)
+    await obs.event("node.end", node="planner", run_step=1)
+    await obs.event("node.start", node="my_router", run_step=1, input="planner")
+    await obs.event("node.end", node="my_router", run_step=1, output="END")
+
+    assert lf.start_as_current_observation.call_count == 3
+    kwargs = lf.start_as_current_observation.call_args_list[2].kwargs
+    assert kwargs["name"] == "my_router"
+    assert kwargs["input"] == "planner"
+    router_obs.update.assert_called_once()
+    assert router_obs.update.call_args.kwargs["output"] == "END"
+    router_obs.end.assert_called_once()
+
+
+@pytest.mark.unit
 def test_langfuse_sink_instantiates():
     lf = MagicMock()
     sink = LangfuseSink(langfuse=lf)

--- a/tests/unit/workflow/test_workflow_observers.py
+++ b/tests/unit/workflow/test_workflow_observers.py
@@ -136,6 +136,43 @@ async def test_router_edge_event(spy_sink: SpySink, agent, seeded_state):
 
 
 @pytest.mark.unit
+async def test_router_emits_node_start_and_end(spy_sink: SpySink, agent, seeded_state):
+    w = Workflow()
+
+    async def noop(a, state, ctx):
+        async def gen():
+            if False:
+                yield
+
+        return gen()
+
+    async def my_router(a, state, ctx):
+        return END
+
+    w.add_node("C", noop)
+    w.add_edge(START, "C")
+    w.add_conditional_edge("C", my_router)
+
+    ctx = InvocationContext(session_id="s1")
+    await w.ainvoke(agent, ctx=ctx, state=seeded_state())
+
+    router_starts = [
+        (n, f)
+        for n, f in spy_sink.events
+        if n == "node.start" and f.get("node") == "my_router"
+    ]
+    router_ends = [
+        (n, f)
+        for n, f in spy_sink.events
+        if n == "node.end" and f.get("node") == "my_router"
+    ]
+    assert len(router_starts) == 1
+    assert len(router_ends) == 1
+    assert router_starts[0][1]["input"] == "C"
+    assert router_ends[0][1]["output"] == END
+
+
+@pytest.mark.unit
 async def test_workflow_start_fields(
     spy_sink: SpySink, agent, seeded_state, noop_workflow
 ):


### PR DESCRIPTION
## Summary

Conditional edge routers were invisible in Langfuse because the workflow only emitted a `node.edge.router` event that the Langfuse sink had no handler for. Routers now emit `node.start` / `node.end` like regular nodes, making them visible as spans with input (source node) and output (chosen destination).

## Changes

- `_next()` in `workflow.py` now emits `node.start` / `node.end` for conditional routers, using the router function's `__name__` as the span name
- `run_step` is passed into `_next()` so the router span carries the correct step metadata
- `node.edge.router` is preserved for other sinks (logging, OTel)
- New unit test `test_router_emits_node_start_and_end` verifies events and fields
- New unit test `test_router_node_creates_span_with_input_and_output` verifies Langfuse sink behaviour
- New integration test `test_conditional_router_appears_as_span` verified end-to-end against Langfuse

## Related

Closes #21

## Commit type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code restructuring, no behaviour change
- [ ] `test` — adding or correcting tests
- [ ] `chore` — maintenance, deps, config, tooling
- [ ] `perf` — performance improvement
- [ ] `ci` — CI/CD pipeline changes

## Release

- [x] `bump:patch` applied — backwards-compatible bug fix
- [ ] `bump:minor` applied — new backwards-compatible functionality
- [ ] `bump:major` applied — breaking change (`!` in commit message)
- [ ] No release needed

## Review checklist

- [x] Code is clear and follows project conventions
- [x] No secrets or credentials introduced
- [x] New behaviour is covered by tests; existing tests pass
- [x] Public API changes are reflected in docstrings and docs
- [x] CI is green (`lint`, `type-check`, `run-pytest`)
- [x] Correct bump label applied (or confirmed not needed)