### PR TITLE
docs: revise and clean up docs, README, and contributing guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           - id: detect-private-key
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.14.14
+      rev: v0.15.12
       hooks:
           - id: ruff-check
             types_or:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,25 +43,25 @@ The repository follows a trunk-based model: all work branches off `main` and mer
 
 ### Main branch
 
-| Branch | Description |
-|--------|-------------|
+| Branch | Description                                                  |
+| ------ | ------------------------------------------------------------ |
 | `main` | Stable, production-ready code. Protected and version-tagged. |
 
 ### Support branches (short-lived)
 
 Branch prefixes mirror [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) types so that branch names and commit messages stay consistent.
 
-| Branch | Origin | Description |
-|--------|--------|-------------|
-| `feat/*` | `main` | New features. |
-| `fix/*` | `main` | Bug fixes. |
-| `docs/*` | `main` | Documentation-only changes. |
+| Branch       | Origin | Description                                  |
+| ------------ | ------ | -------------------------------------------- |
+| `feat/*`     | `main` | New features.                                |
+| `fix/*`      | `main` | Bug fixes.                                   |
+| `docs/*`     | `main` | Documentation-only changes.                  |
 | `refactor/*` | `main` | Code restructuring with no behaviour change. |
-| `test/*` | `main` | Test additions or corrections. |
-| `chore/*` | `main` | Maintenance tasks (deps, config, tooling). |
-| `perf/*` | `main` | Performance improvements. |
-| `ci/*` | `main` | CI/CD pipeline changes. |
-| `junk/*` | `main` | Experimental work. **Never merged.** |
+| `test/*`     | `main` | Test additions or corrections.               |
+| `chore/*`    | `main` | Maintenance tasks (deps, config, tooling).   |
+| `perf/*`     | `main` | Performance improvements.                    |
+| `ci/*`       | `main` | CI/CD pipeline changes.                      |
+| `junk/*`     | `main` | Experimental work. **Never merged.**         |
 
 ### Workflow
 
@@ -106,13 +106,13 @@ Include the issue number before the description — GitHub will automatically li
 
 Use the GitHub issue templates — they enforce the required fields and apply the correct label automatically:
 
-| Template | CC label | Use when |
-|----------|----------|----------|
-| Bug report | `fix` | Something isn't working correctly |
-| Feature request | `feat` | Proposing new functionality |
-| Documentation | `docs` | Missing, outdated, or incorrect docs |
-| Task | `refactor` / `test` / `chore` / `perf` / `ci` | Maintenance or internal work |
-| Change request | `change-request` | Significant change needing approval first |
+| Template        | CC label                                      | Use when                                  |
+| --------------- | --------------------------------------------- | ----------------------------------------- |
+| Bug report      | `fix`                                         | Something isn't working correctly         |
+| Feature request | `feat`                                        | Proposing new functionality               |
+| Documentation   | `docs`                                        | Missing, outdated, or incorrect docs      |
+| Task            | `refactor` / `test` / `chore` / `perf` / `ci` | Maintenance or internal work              |
+| Change request  | `change-request`                              | Significant change needing approval first |
 
 Issue titles are pre-filled with the matching CC prefix (e.g. `fix: `, `feat: `) — keep that prefix so the title can be reused directly in a commit message.
 
@@ -122,12 +122,12 @@ Issue titles are pre-filled with the matching CC prefix (e.g. `fix: `, `feat: `)
 
 Every issue must carry exactly one priority label — set it after the template auto-applies the type label:
 
-| Label | When to use |
-|-------|-------------|
-| `priority:critical` | Production is broken |
-| `priority:high` | Major functionality affected |
-| `priority:medium` | Workaround exists |
-| `priority:low` | Cosmetic or minor impact |
+| Label               | When to use                  |
+| ------------------- | ---------------------------- |
+| `priority:critical` | Production is broken         |
+| `priority:high`     | Major functionality affected |
+| `priority:medium`   | Workaround exists            |
+| `priority:low`      | Cosmetic or minor impact     |
 
 ---
 
@@ -207,12 +207,12 @@ uv run mkdocs build   # static build
 ### Submitting
 
 1. Open the PR — GitHub will auto-populate the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
-2. Fill in every section completely — incomplete PRs will be returned.
-3. Tick the correct **commit type** and apply the appropriate **bump label** (or confirm none is needed).
-4. Ensure all CI jobs pass (`lint`, `type-check`, `run-pytest`).
-5. Keep PRs focused: one concern per PR.
-6. Request at least **one review** from a project maintainer.
-7. Do not force-push once a review has started — add new commits instead.
+1. Fill in every section completely — incomplete PRs will be returned.
+1. Tick the correct **commit type** and apply the appropriate **bump label** (or confirm none is needed).
+1. Ensure all CI jobs pass (`lint`, `type-check`, `run-pytest`).
+1. Keep PRs focused: one concern per PR.
+1. Request at least **one review** from a project maintainer.
+1. Do not force-push once a review has started — add new commits instead.
 
 ### Review checklist
 
@@ -236,11 +236,11 @@ Releases are fully automated and triggered by a label on the merged PR.
 
 Apply exactly one of these labels before merging:
 
-| Label | Semver segment bumped | When to use |
-|-------|-----------------------|-------------|
-| `bump:patch` | `x.y.Z` | Backwards-compatible bug fixes |
-| `bump:minor` | `x.Y.0` | New backwards-compatible functionality |
-| `bump:major` | `X.0.0` | Breaking changes |
+| Label        | Semver segment bumped | When to use                            |
+| ------------ | --------------------- | -------------------------------------- |
+| `bump:patch` | `x.y.Z`               | Backwards-compatible bug fixes         |
+| `bump:minor` | `x.Y.0`               | New backwards-compatible functionality |
+| `bump:major` | `X.0.0`               | Breaking changes                       |
 
 PRs without a bump label are merged silently — no release is cut.
 
@@ -289,6 +289,7 @@ docs(workflow): document sequencing behaviour for parallel steps
 ```
 
 Rules:
+
 - Subject line ≤ 72 characters, imperative mood, no trailing period.
 - Use `!` after the type to signal urgent or breaking changes (e.g. `fix!:`, `feat!:`).
 - Reference related issues and PRs in the footer using `#<number>`.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
   <img alt="ANT AI" src="https://raw.githubusercontent.com/idea-idsia/ant-ai/main/docs/assets/ant_h_dark.png" height="100">
 </picture>
 
-![Python](https://img.shields.io/badge/python-3.14%2B-4584b6?logo=python&logoColor=white)
-![License](https://img.shields.io/badge/license-MIT-blue?logo=MIT&logoColor=white-lightgrey)
-[![Coverage](https://codecov.io/gh/idea-idsia/ant-ai/branch/main/graph/badge.svg)](https://codecov.io/gh/idea-idsia/ant-ai)
-[![Docs](https://img.shields.io/badge/docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://idea-idsia.github.io/ant-ai/)
+![Python](https://img.shields.io/badge/Python-3.14%2B-3776AB?logo=python&logoColor=white)
+![License](https://img.shields.io/badge/License-MIT-green)
+![PyPI - Version](https://img.shields.io/pypi/v/ant-ai?label=PyPI)
+[![Coverage](https://img.shields.io/codecov/c/github/idea-idsia/ant-ai?label=Coverage&logo=codecov)](https://codecov.io/gh/idea-idsia/ant-ai)
+[![Docs](https://img.shields.io/badge/Docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://idea-idsia.github.io/ant-ai/)
 
 **A lightweight Python framework for building tool-driven AI agents and multi-agent systems.**
 
@@ -20,13 +21,13 @@
 
 ## Why ANT AI
 
-**Multi-agent by design.** Agents communicate and delegate natively via the [A2A protocol](https://github.com/a2aproject/A2A) — build systems that grow without rewrites.
+**Multi-agent by design.** Agents communicate and delegate via the [A2A protocol](https://github.com/a2aproject/A2A) — no custom glue code required.
 
-**No lock-in.** Swap LLMs, tools, or observability backends in one line. Your logic stays untouched.
+**No lock-in.** Swap LLMs, tools, or observability backends without touching your agent logic.
 
-**Structured, not scripted.** Model complex behavior as graphs. Know exactly what runs, when, and why.
+**Structured, not scripted.** Model complex behavior as graphs — know exactly what runs, when, and why.
 
-**Production-ready out of the box.** Hooks, guardrails, and full observability via [Langfuse](https://langfuse.com/) and OpenTelemetry — without extra setup.
+**Observable from day one.** Built-in tracing via [Langfuse](https://langfuse.com/) and lifecycle hooks for guardrails.
 
 ## Installation
 
@@ -39,9 +40,9 @@ uv add ant-ai
 Or clone and sync for local development:
 
 ```sh
-git clone https://github.com/idea-idsia/ant-ai
+git clone git@github.com:idea-idsia/ant-ai.git
 cd ant-ai
-uv sync --all-extras
+uv sync --all-packages --all-groups --all-extras
 ```
 
 ## Quickstart

--- a/docs/docs/architecture/index.md
+++ b/docs/docs/architecture/index.md
@@ -6,16 +6,16 @@ title: Architecture
 
 ## Components
 
-| Module                           | Component                                                                                               | Responsibility                                                                                                                                                                    |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <nobr>`ant_ai.agent`</nobr>    | [`Agent`][ant_ai.agent.agent.Agent]                                                                   | Core reasoning unit. Runs the ReAct loop: queries the LLM, executes tool calls, and streams events until a final answer is reached.                                               |
-| <nobr>`ant_ai.workflow`</nobr> | [`Workflow`][ant_ai.workflow.workflow.Workflow]                                                       | Directed graph of nodes (actions) connected by static edges or conditional routers. Orchestrates what the agent does and in what order.                                           |
-| <nobr>`ant_ai.tools`</nobr>    | [`Tool`][ant_ai.tools.tool.Tool]                                                                      | Callables exposed to the LLM via JSON schema. Defined with the `@tool` decorator or as a `Tool` subclass for grouped namespaces.                                                  |
-|                                  | [`ToolRegistry`][ant_ai.tools.registry.ToolRegistry]                                                  | Built automatically from the agent's tool list. Expands namespace tools into individually callable entries.                                                                       |
-| <nobr>`ant_ai.a2a`</nobr>      | [`Colony`][ant_ai.a2a.colony.Colony]                                                                        | Multi-agent coordinator. Registers agents with their workflows and A2A cards, wires collaboration edges, and produces ASGI apps for deployment.                                   |
-|                                  | [`A2AExecutor`][ant_ai.a2a.executor.A2AExecutor]                                                      | ASGI request handler. Receives incoming A2A requests, initialises `InvocationContext` and `State`, drives `Workflow.stream()`, and translates events to A2A task updates. |
-|                                  | [`A2AAgentTool`][ant_ai.a2a.agent.A2AAgentTool]                                                       | A `Tool` that calls a remote agent over HTTP. Added to source agents automatically by `Colony.collab()`.                                                                            |
-| <nobr>`ant_ai.core`</nobr>     | [`AgentEvent`][ant_ai.core.events.AgentEvent] / [`WorkflowEvent`][ant_ai.core.events.WorkflowEvent] | Typed events emitted by the agent and workflow respectively. All progress — LLM output, tool calls, node transitions — is observable through this stream.                         |
+| Module                         | Component                                                                                           | Responsibility                                                                                                                                                            |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <nobr>`ant_ai.agent`</nobr>    | [`Agent`][ant_ai.agent.agent.Agent]                                                                 | Core reasoning unit. Runs the ReAct loop: queries the LLM, executes tool calls, and streams events until a final answer is reached.                                       |
+| <nobr>`ant_ai.workflow`</nobr> | [`Workflow`][ant_ai.workflow.workflow.Workflow]                                                     | Directed graph of nodes (actions) connected by static edges or conditional routers. Orchestrates what the agent does and in what order.                                   |
+| <nobr>`ant_ai.tools`</nobr>    | [`Tool`][ant_ai.tools.tool.Tool]                                                                    | Callables exposed to the LLM via JSON schema. Defined with the `@tool` decorator or as a `Tool` subclass for grouped namespaces.                                          |
+|                                | [`ToolRegistry`][ant_ai.tools.registry.ToolRegistry]                                                | Built automatically from the agent's tool list. Expands namespace tools into individually callable entries.                                                               |
+| <nobr>`ant_ai.a2a`</nobr>      | [`Colony`][ant_ai.a2a.colony.Colony]                                                                | Multi-agent coordinator. Registers agents with their workflows and A2A cards, wires collaboration edges, and produces ASGI apps for deployment.                           |
+|                                | [`A2AExecutor`][ant_ai.a2a.executor.A2AExecutor]                                                    | ASGI request handler. Receives incoming A2A requests, initialises `InvocationContext` and `State`, drives `Workflow.stream()`, and translates events to A2A task updates. |
+|                                | [`A2AAgentTool`][ant_ai.a2a.agent.A2AAgentTool]                                                     | A `Tool` that calls a remote agent over HTTP. Added to source agents automatically by `Colony.collab()`.                                                                  |
+| <nobr>`ant_ai.core`</nobr>     | [`AgentEvent`][ant_ai.core.events.AgentEvent] / [`WorkflowEvent`][ant_ai.core.events.WorkflowEvent] | Typed events emitted by the agent and workflow respectively. All progress — LLM output, tool calls, node transitions — is observable through this stream.                 |
 
 A high level view of the interaction of these components is shown below:
 
@@ -72,7 +72,7 @@ flowchart TD
 
 ## Flow of a Request
 
-In the A2A integration, [`A2AExecutor.execute()`][ant_ai.a2a.executor.A2AExecutor.execute] acts as the streaming entrypoint: it ensures there is an active [`Task`](https://a2a-protocol.org/latest/sdk/python/api/a2a.html#a2a.types.Task), builds an [`InvocationContext`][ant_ai.core.types.InvocationContext] and initial [`State`][ant_ai.core.types.State] (including converted history), then consumes the asynchronous event stream produced by [`Workflow.stream()`][ant_ai.workflow.workflow.Workflow]. The workflow is a graph of actions (nodes) connected by static edges or routers; each node execution emits [`WorkflowEvent`][ant_ai.core.events.WorkflowEvent] updates (started/completed/update) and may delegate to the [`Agent`][ant_ai.agent.agent.Agent] for LLM-driven logic (including tool calls), which surfaces as [`AgentEvent`][ant_ai.core.events.AgentEvent] (`update`, `tool_calling`, `tool_result`, `final`). Every event, whether originating from the workflow or the agent, is translated via [`HVEventToA2A.apply()`][ant_ai.a2a.translator.HVEventToA2A.apply] and applied to the task through [`TaskUpdater`](https://a2a-protocol.org/latest/sdk/python/api/a2a.server.tasks.html#a2a.server.tasks.TaskUpdater), resulting in incremental task updates being streamed back to the client; this makes progress observable end-to-end until the workflow emits a final `COMPLETED` event and the task reaches a terminal state.
+In the A2A integration, [`A2AExecutor.execute()`][ant_ai.a2a.executor.A2AExecutor.execute] acts as the streaming entrypoint: it ensures there is an active [`Task`](https://a2a-protocol.org/latest/sdk/python/api/a2a.html#a2a.types.Task), builds an [`InvocationContext`][ant_ai.core.types.InvocationContext] and initial [`State`][ant_ai.core.types.State] (including converted history), then consumes the asynchronous event stream produced by [`Workflow.stream()`][ant_ai.workflow.workflow.Workflow]. The workflow is a directed graph of actions (nodes) connected by static edges or conditional routers; it opens with a [`StartEvent`][ant_ai.core.events.StartEvent], wraps each node in a pair of [`UpdateEvent`][ant_ai.core.events.UpdateEvent]s (node started / node completed), and closes with a [`CompletedEvent`][ant_ai.core.events.CompletedEvent]. Within each node the [`Agent`][ant_ai.agent.agent.Agent] runs its ReAct loop, emitting [`ReasoningEvent`][ant_ai.core.events.ReasoningEvent] (extended-thinking models only), [`ToolCallingEvent`][ant_ai.core.events.ToolCallingEvent] / [`ToolResultEvent`][ant_ai.core.events.ToolResultEvent] for each tool round-trip, and finally a [`FinalAnswerEvent`][ant_ai.core.events.FinalAnswerEvent] when the LLM produces a plain-text response. Every event is translated via [`HVEventToA2A.apply()`][ant_ai.a2a.translator.HVEventToA2A.apply] and applied to the task through [`TaskUpdater`](https://a2a-protocol.org/latest/sdk/python/api/a2a.server.tasks.html#a2a.server.tasks.TaskUpdater), streaming incremental updates back to the client until the workflow reaches a terminal state.
 
 ```mermaid
 ---
@@ -90,11 +90,11 @@ sequenceDiagram
     Client->>Exec: Send request
     Exec->>WF: Start workflow stream
 
-        WF-->>Exec: WorkflowEvent (START)
+        WF-->>Exec: StartEvent
         Exec-->>Client: Stream update
 
         loop For each action/node (many)
-            WF-->>Exec: WorkflowEvent (Action STARTED)
+            WF-->>Exec: UpdateEvent (node started)
             Exec-->>Client: Stream update
 
             WF->>Act: Run action
@@ -103,26 +103,83 @@ sequenceDiagram
             loop ReAct iterations (many)
                 Agent->>LLM: Query LLM
                 LLM-->>Agent: Response
-                Agent-->>Exec: AgentEvent (update)
-                Exec-->>Client: Stream update
 
-                opt Tools (many)
-                    Agent-->>Exec: AgentEvent (tool call)
+                opt Reasoning (extended thinking models)
+                    Agent-->>Exec: ReasoningEvent
                     Exec-->>Client: Stream update
-                    Agent-->>Exec: AgentEvent (tool result)
+                end
+
+                alt Tool calls requested
+                    Agent-->>Exec: ToolCallingEvent
+                    Exec-->>Client: Stream update
+                    Agent-->>Exec: ToolResultEvent (per tool)
+                    Exec-->>Client: Stream update
+                else No tool calls
+                    Agent-->>Exec: FinalAnswerEvent
                     Exec-->>Client: Stream update
                 end
             end
 
-            Agent-->>Exec: AgentEvent (final)
-            Exec-->>Client: Stream update
-
-            WF-->>Exec: WorkflowEvent (Action COMPLETED)
+            WF-->>Exec: UpdateEvent (node completed)
             Exec-->>Client: Stream update
 
             WF->>WF: Select next action (edge/router)
         end
 
-        WF-->>Exec: WorkflowEvent (COMPLETED)
+        WF-->>Exec: CompletedEvent
         Exec-->>Client: Stream update
+```
+
+## Events
+
+Every step of agent and workflow execution is observable through a stream of typed events. All events extend [`Event`][ant_ai.core.events.Event].
+
+### Workflow events
+
+Emitted by [`Workflow`][ant_ai.workflow.workflow.Workflow] to signal lifecycle transitions and node progress.
+
+| Class                                                 | `kind`        | When emitted                                                                   |
+| ----------------------------------------------------- | ------------- | ------------------------------------------------------------------------------ |
+| [`StartEvent`][ant_ai.core.events.StartEvent]         | `"start"`     | Workflow begins execution                                                      |
+| [`UpdateEvent`][ant_ai.core.events.UpdateEvent]       | `"update"`    | Node started (`"Starting action 'X'"`) or completed (`"Completed action 'X'"`) |
+| [`CompletedEvent`][ant_ai.core.events.CompletedEvent] | `"completed"` | Workflow finished successfully; `content` holds the final answer               |
+
+### Agent events
+
+Emitted by the agent's ReAct loop during LLM calls and tool execution.
+
+| Class                                                                     | `kind`                | When emitted                                                                                                   |
+| ------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [`ReasoningEvent`][ant_ai.core.events.ReasoningEvent]                     | `"reasoning"`         | Model produced extended thinking / reasoning text (before the answer)                                          |
+| [`ToolCallingEvent`][ant_ai.core.events.ToolCallingEvent]                 | `"tool_calling"`      | LLM response contains tool calls; `message` holds the [`ToolCallMessage`][ant_ai.core.message.ToolCallMessage] |
+| [`ToolResultEvent`][ant_ai.core.events.ToolResultEvent]                   | `"tool_result"`       | One tool call completed; `content` holds the result                                                            |
+| [`FinalAnswerEvent`][ant_ai.core.events.FinalAnswerEvent]                 | `"final_answer"`      | LLM produced a plain-text response (no tool calls); ends the ReAct loop                                        |
+| [`MaxStepsReachedEvent`][ant_ai.core.events.MaxStepsReachedEvent]         | `"max_steps_reached"` | Agent exhausted its maximum allowed ReAct steps                                                                |
+| [`ClarificationNeededEvent`][ant_ai.core.events.ClarificationNeededEvent] | `"input_required"`    | Agent determined it needs human input to proceed                                                               |
+
+### Consuming events
+
+```python
+from ant_ai.core.events import (
+    StartEvent, UpdateEvent, CompletedEvent,
+    ReasoningEvent, ToolCallingEvent, ToolResultEvent,
+    FinalAnswerEvent, MaxStepsReachedEvent,
+)
+
+async for event in workflow.stream(agent, ctx=ctx, state=state):
+    match event:
+        case StartEvent():
+            print("workflow started")
+        case UpdateEvent():
+            print("node update:", event.content, f"[{event.origin.node}]")
+        case ReasoningEvent():
+            print("thinking:", event.content)
+        case ToolCallingEvent():
+            print("calling tools:", event.message)
+        case ToolResultEvent():
+            print("tool result:", event.content)
+        case FinalAnswerEvent():
+            print("answer:", event.content)
+        case CompletedEvent():
+            print("workflow done:", event.content)
 ```

--- a/docs/docs/multi-agent/example.md
+++ b/docs/docs/multi-agent/example.md
@@ -4,14 +4,14 @@ title: Example
 
 # Multi-agent example: Software Engineering Colony
 
-This example walks through a three-agent colony that collaborates to write, test, and review Python code. The setup mirrors the `hv_agent_service` reference implementation.
+This example walks through a three-agent colony that collaborates to write, test, and review Python code.
 
 ## Agents
 
-| Agent | Port | Responsibility | Can call |
-|-------|------|----------------|----------|
-| `codegen` | 9001 | Writes Python code | `testgen` |
-| `testgen` | 9002 | Writes pytest tests | `codegen` |
+| Agent     | Port | Responsibility       | Can call  |
+| --------- | ---- | -------------------- | --------- |
+| `codegen` | 9001 | Writes Python code   | `testgen` |
+| `testgen` | 9002 | Writes pytest tests  | `codegen` |
 | `quality` | 9003 | Reviews code quality | `codegen` |
 
 The collaboration graph:
@@ -196,30 +196,30 @@ python -m myapp start quality   # → 0.0.0.0:9003
 
 ```yaml
 services:
-  codegen-agent:
-    build: .
-    command: python -m myapp start codegen
-    ports:
-      - "9001:9001"
+    codegen-agent:
+        build: .
+        command: python -m myapp start codegen
+        ports:
+            - "9001:9001"
 
-  testgen-agent:
-    build: .
-    command: python -m myapp start testgen
-    ports:
-      - "9002:9002"
+    testgen-agent:
+        build: .
+        command: python -m myapp start testgen
+        ports:
+            - "9002:9002"
 
-  quality-agent:
-    build: .
-    command: python -m myapp start quality
-    ports:
-      - "9003:9003"
+    quality-agent:
+        build: .
+        command: python -m myapp start quality
+        ports:
+            - "9003:9003"
 
-  db:
-    image: postgres:17
-    environment:
-      POSTGRES_DB: ant_ai
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: pass
+    db:
+        image: postgres:17
+        environment:
+            POSTGRES_DB: ant_ai
+            POSTGRES_USER: user
+            POSTGRES_PASSWORD: pass
 ```
 
 The `Colony` uses service names (`codegen-agent`, `testgen-agent`, `quality-agent`) as hostnames, matching the URLs in each `AgentCard.supported_interfaces`.
@@ -227,7 +227,7 @@ The `Colony` uses service names (`codegen-agent`, `testgen-agent`, `quality-agen
 ## How a request flows
 
 1. A client sends `"Write a function that sorts a list"` to the `codegen` agent.
-2. `codegen` runs `generate_code` → `validate_code`. In the process, it can optionally call `testgen` to generate tests.
-3. `testgen` receives the code from `codegen`, generates tests, validates them, and returns the result.
-4. `codegen` incorporates the test output and produces its final answer.
-5. Independently, `quality` can be called to review any code, and may in turn call `codegen` to fix issues it finds.
+1. `codegen` runs `generate_code` → `validate_code`. In the process, it can optionally call `testgen` to generate tests.
+1. `testgen` receives the code from `codegen`, generates tests, validates them, and returns the result.
+1. `codegen` incorporates the test output and produces its final answer.
+1. Independently, `quality` can be called to review any code, and may in turn call `codegen` to fix issues it finds.

--- a/docs/docs/single-agent/index.md
+++ b/docs/docs/single-agent/index.md
@@ -122,13 +122,13 @@ asyncio.run(main())
 
 Key event classes (all in [`ant_ai.core.events`][ant_ai.core.events]):
 
-| Class                                                                          | Meaning                         |
-| ------------------------------------------------------------------------------ | ------------------------------- |
-| [`UpdateEvent`][ant_ai.core.events.UpdateEvent]                              | Intermediate LLM output         |
-| [`ToolCallingEvent`][ant_ai.core.events.ToolCallingEvent]                    | Agent is about to call a tool   |
-| [`ToolResultEvent`][ant_ai.core.events.ToolResultEvent]                      | Tool returned a result          |
-| [`FinalAnswerEvent`][ant_ai.core.events.FinalAnswerEvent]                    | Agent produced its final answer |
-| [`MaxStepsReachedEvent`][ant_ai.core.events.MaxStepsReachedEvent]            | Loop hit the step limit         |
+| Class                                                               | Meaning                         |
+| ------------------------------------------------------------------- | ------------------------------- |
+| [`UpdateEvent`][ant_ai.core.events.UpdateEvent]                   | Intermediate LLM output         |
+| [`ToolCallingEvent`][ant_ai.core.events.ToolCallingEvent]         | Agent is about to call a tool   |
+| [`ToolResultEvent`][ant_ai.core.events.ToolResultEvent]           | Tool returned a result          |
+| [`FinalAnswerEvent`][ant_ai.core.events.FinalAnswerEvent]         | Agent produced its final answer |
+| [`MaxStepsReachedEvent`][ant_ai.core.events.MaxStepsReachedEvent] | Loop hit the step limit         |
 
 ## Adding a Workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ title: Home
 
 ## Quick start
 
+```bash
+uv add ant-ai
+```
+
+Then try it out:
+
 ```python
 import asyncio
 
@@ -47,7 +53,7 @@ asyncio.run(main())
 
 ## Next steps
 
-- **[Install](docs/install/index.md)** — get `ant-ai` installed in your project.
+- **[Install](docs/install/index.md)** — optional extras, installing from source, and verifying your setup.
 - **[Single-agent guide](docs/single-agent/index.md)** — build an agent with tools.
 - **[Multi-agent guide](docs/multi-agent/index.md)** — connect agents in a Colony.
 - **[Architecture](docs/architecture/index.md)** — how events flow through the system.


### PR DESCRIPTION
## What & Why

This PR cleans up and improves the documentation, README, and contributing guide. It expands the architecture page with a proper event reference, and polishes formatting throughout.

## Changes

- Expand architecture page with typed event reference tables (workflow events, agent events) and a consuming-events code example
- Update sequence diagram to use correct event class names (`StartEvent`, `UpdateEvent`, `CompletedEvent`, etc.)
- Refresh README badges (add PyPI version badge, fix coverage badge URL) and tighten copy
- Bump ruff pre-commit hook from `v0.14.14` to `v0.15.12`

## Closes

Closes #

## Release

- [ ] `bump:patch` — bug fix
- [ ] `bump:minor` — new functionality
- [ ] `bump:major` — breaking change

## Docs

Architecture event reference section added to `docs/docs/architecture/index.md`. Single-agent and multi-agent pages updated for consistency with current event API.