### PR TITLE
docs(site): add funding page to docs navigation

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,5 +1,7 @@
 nav:
-    - Home: index.md
+    - Home:
+        - index.md
+        - Funding: funding.md
     - Docs: docs
     - Reference:
           - Overview: reference/

--- a/docs/funding.md
+++ b/docs/funding.md
@@ -1,0 +1,12 @@
+---
+title: Funding
+---
+
+# Funding
+
+This project is supported by the following grants.
+
+| Acknowledgement |
+| --------------- |
+| Funded by the Swiss State Secretariat for Education, Research and Innovation (SERI), Project number 24.00596. |
+| Funded by the European Union under Grant Agreement No. 101189745 (HIVEMIND).<br><img src="https://ec.europa.eu/regional_policy/images/information-sources/logo-download-center/eu_funded_en.jpg" alt="Funded by the European Union" style="height:40px;width:auto;"/> |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
         - navigation.instant
         - navigation.tracking
         - navigation.sections
+        - navigation.indexes
         - content.code.copy
         - content.action.edit
 
@@ -42,8 +43,8 @@ theme:
 
 plugins:
     - search
-    - section-index
     - awesome-nav
+    - section-index
     - panzoom
 
     - gen-files:


### PR DESCRIPTION
## Summary

- Adds a dedicated `funding.md` page to the docs site listing the SERI and EU HIVEMIND grant acknowledgements
- Adds the page to the Home section sidebar via `.nav.yml`
- Enables `navigation.indexes` in `mkdocs.yml` so the Home section header links directly to `index.md` without a duplicate entry
- Reorders `section-index` plugin to run after `awesome-nav` as required