### PR TITLE
feat(memory): add pluggable memory interface with mem0 backend

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -9,6 +9,7 @@ nav:
           - Agent: reference/agent/
           - Tools: reference/tools/
           - LLM: reference/llm/
+          - Memory: reference/memory/
           - Workflow: reference/workflow/
           - A2A: reference/a2a/
           - Hooks: reference/hooks/

--- a/docs/docs/single-agent/.nav.yml
+++ b/docs/docs/single-agent/.nav.yml
@@ -1,4 +1,5 @@
 nav:
     - index.md
     - example.md
+    - memory.md
     - visualize.md

--- a/docs/docs/single-agent/memory.md
+++ b/docs/docs/single-agent/memory.md
@@ -1,0 +1,128 @@
+---
+title: Memory
+---
+
+# Agent memory
+
+The `memory` field on [`Agent`][ant_ai.agent.agent.Agent] connects a pluggable long-term memory backend that persists knowledge across conversations.
+
+## How it works
+
+On every call to `agent.stream()`:
+
+1. **Retrieve** — before the first LLM step the agent queries the memory store with the latest user message and prepends any matching memories as `system` messages.
+2. **Consolidate** — once a final answer is produced (or the step limit is reached) the user message and assistant reply are written back to the store.
+
+Both steps are no-ops when `memory` is `None`, so existing agents are unaffected.
+
+## The `Memory` interface
+
+[`Memory`][ant_ai.memory.protocol.Memory] is the abstract base class. Implement two async methods to connect any backend:
+
+```python
+from ant_ai.memory import Memory
+from ant_ai.core.message import Message
+from ant_ai.core.types import InvocationContext
+
+class MyMemory(Memory):
+    async def retrieve(
+        self, query: str, *, top_k: int = 5, **kwargs
+    ) -> list[Message]:
+        # Return relevant memories as system messages
+        ...
+
+    async def update(self, messages: list[Message], **kwargs) -> None:
+        # Persist messages for future retrieval
+        ...
+```
+
+Both methods receive `ctx: InvocationContext` via `**kwargs`. Use `ctx.user_id` for cross-session scoping.
+
+## Built-in backend: mem0
+
+[`Mem0Memory`][ant_ai.memory.backends.mem0.Mem0Memory] wraps the [mem0](https://app.mem0.ai/) cloud client. It requires a `MEM0_API_KEY` environment variable or an explicit `api_key` argument.
+
+```python
+from ant_ai import Agent
+from ant_ai.llm.integrations import LiteLLMChat
+from ant_ai.memory.backends.mem0 import Mem0Memory
+
+agent = Agent(
+    name="Assistant",
+    llm=LiteLLMChat("gpt-5-mini"),
+    system_prompt="You are a helpful assistant.",
+    memory=Mem0Memory(),           # picks up MEM0_API_KEY from the environment
+)
+```
+
+## Scoping memories to a user
+
+Pass `user_id` through [`InvocationContext`][ant_ai.core.types.InvocationContext] to keep each user's memories isolated:
+
+```python
+from ant_ai import InvocationContext, Message, State
+
+ctx = InvocationContext(session_id="session-abc", user_id="alice")
+state = State()
+state.add_message(Message(role="user", content="My favourite language is Python."))
+
+async for event in agent.stream(state, ctx=ctx):
+    ...
+```
+
+On the next invocation with the same `user_id`, the agent will recall that preference automatically.
+
+When `user_id` is absent the backend falls back to `session_id`, which gives run-scoped memory (useful for long single-session tasks).
+
+## A2A: passing `user_id` from metadata
+
+When running behind an [A2A](../multi-agent/index.md) server, pass `user_id` in the task metadata:
+
+```python
+task_client.send_task(
+    message="...",
+    metadata={"user_id": "alice"},
+)
+```
+
+The [`A2AExecutor`][ant_ai.a2a.executor.A2AExecutor] forwards it into `InvocationContext` automatically.
+
+## Full example
+
+```python
+import asyncio
+from ant_ai import Agent, Message, State, InvocationContext
+from ant_ai.llm.integrations import LiteLLMChat
+from ant_ai.memory.backends.mem0 import Mem0Memory
+from ant_ai.core import FinalAnswerEvent
+
+agent = Agent(
+    name="Assistant",
+    llm=LiteLLMChat("gpt-5-mini"),
+    system_prompt="You are a helpful assistant with long-term memory.",
+    memory=Mem0Memory(),
+)
+
+async def chat(user_id: str, text: str) -> str:
+    ctx = InvocationContext(session_id="s1", user_id=user_id)
+    state = State()
+    state.add_message(Message(role="user", content=text))
+    result = ""
+    async for event in agent.stream(state, ctx=ctx):
+        if isinstance(event, FinalAnswerEvent):
+            result = event.content
+    return result
+
+async def main():
+    # First session — agent learns the preference
+    await chat("alice", "I am from Italy")
+
+    # mem0 cloud indexing is async; wait for the memory to become searchable.
+    await asyncio.sleep(10)
+
+    # Second session — agent remembers without being told again
+    reply = await chat("alice", "What's the capital of my country?")
+    print(reply)
+
+asyncio.run(main())
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 langfuse = ["langfuse>=4.3.1"]
+mem0 = ["mem0ai>=0.1.0"]
 openai = ["openai>=2.24.0"]
 viz = ["graphviz>=0.20"]
 

--- a/pytest.toml
+++ b/pytest.toml
@@ -20,4 +20,5 @@ markers = [
     "multi_agent: integration tests that involve multiple agents",
     "postgres: tests that require a running PostgreSQL instance (set POSTGRES_TEST_URL env var)",
     "graphviz: tests that require the graphviz package and dot CLI to be installed",
+    "mem0: tests that require the mem0 cloud service (set MEM0_API_KEY)",
 ]

--- a/src/ant_ai/__init__.py
+++ b/src/ant_ai/__init__.py
@@ -10,6 +10,7 @@ from ant_ai.core import (
     StepResult,
     configure_logging,
 )
+from ant_ai.memory import Memory
 from ant_ai.observer import CompositeSink, ObservabilitySink, obs
 from ant_ai.tools import Tool, ToolRegistry
 from ant_ai.tools.tool import tool
@@ -19,6 +20,8 @@ __all__ = [
     # agent
     "Agent",
     "BaseAgent",
+    # memory
+    "Memory",
     # core
     "Message",
     "AnyMessage",

--- a/src/ant_ai/a2a/executor.py
+++ b/src/ant_ai/a2a/executor.py
@@ -99,6 +99,7 @@ class A2AExecutor(AgentExecutor):
     ) -> None:
         ctx = InvocationContext(
             session_id=task.context_id,
+            user_id=context.metadata.get("user_id", None),
             llm_settings=context.metadata.get("llm_settings", None),
             workflow_settings=context.metadata.get("workflow_settings", None),
         )

--- a/src/ant_ai/agent/agent.py
+++ b/src/ant_ai/agent/agent.py
@@ -24,6 +24,7 @@ class Agent(BaseAgent):
             else None,
             hooks=self._hook_layer,
             max_retries=self.max_retries,
+            memory=self.memory,
         )
 
     def add_tool(self, tool: Tool) -> None:

--- a/src/ant_ai/agent/base.py
+++ b/src/ant_ai/agent/base.py
@@ -21,6 +21,7 @@ from ant_ai.core.types import InvocationContext, State
 from ant_ai.hooks.layer import HookLayer
 from ant_ai.hooks.protocol import AgentHook
 from ant_ai.llm.protocol import ChatLLM
+from ant_ai.memory.protocol import Memory
 from ant_ai.observer import obs
 from ant_ai.tools.registry import ToolRegistry
 from ant_ai.tools.tool import Tool
@@ -52,6 +53,10 @@ class BaseAgent(BaseModel):
     hooks: list[AgentHook] = Field(
         default_factory=list,
         description="Lifecycle hooks for the agent.",
+    )
+    memory: Memory | None = Field(
+        default=None,
+        description="Pluggable memory backend for cross-session context.",
     )
     max_retries: int = Field(
         default=3,

--- a/src/ant_ai/agent/loop/loop.py
+++ b/src/ant_ai/agent/loop/loop.py
@@ -19,6 +19,7 @@ from ant_ai.hooks import (
     PostModelRetry,
     WrapCall,
 )
+from ant_ai.memory.protocol import Memory
 from ant_ai.observer import obs
 from ant_ai.steps import Step
 from ant_ai.tools.registry import ToolRegistry
@@ -36,6 +37,34 @@ class BaseAgentLoop(ABC, BaseModel):
 
     hooks: HookLayer = Field(default_factory=HookLayer)
     max_retries: int = Field(default=3, ge=1)
+    memory: Memory | None = None
+
+    async def _retrieve_memories(
+        self, state: State, ctx: InvocationContext | None
+    ) -> None:
+        """Retrieve relevant memories from the store and prepend them to state."""
+        if self.memory is None:
+            return
+        user_query: str | None = next(
+            (m.content for m in reversed(state.messages) if m.role == "user"), ""
+        )
+        if not user_query:
+            return
+        memory_msgs: list[Message] = await self.memory.retrieve(user_query, ctx=ctx)
+        state.messages[0:0] = memory_msgs
+
+    async def _consolidate_memories(
+        self,
+        messages: list[Message | None],
+        ctx: InvocationContext | None,
+    ) -> None:
+        """Persist the current-turn exchange to memory."""
+        if self.memory is None:
+            return
+        to_store: list[Message] = [m for m in messages if m is not None and m.content]
+        if not to_store:
+            return
+        await self.memory.update(to_store, ctx=ctx)
 
     @abstractmethod
     def stream(

--- a/src/ant_ai/agent/loop/react.py
+++ b/src/ant_ai/agent/loop/react.py
@@ -138,11 +138,11 @@ class ReActLoop(BaseAgentLoop):
                         role="assistant", content=final_event.content
                     )
                     state.add_message(assistant_msg)
-                    yield final_event
                     if self.memory is not None:
                         await self._consolidate_memories(
                             [_trigger_msg, assistant_msg], ctx
                         )
+                    yield final_event
                     return
 
         if self.memory is not None:

--- a/src/ant_ai/agent/loop/react.py
+++ b/src/ant_ai/agent/loop/react.py
@@ -22,7 +22,6 @@ from ant_ai.core.result import (
 )
 from ant_ai.core.types import InvocationContext, State
 from ant_ai.hooks import WrapCall
-from ant_ai.memory.protocol import Memory
 from ant_ai.steps import LLMStep, ToolStep
 from ant_ai.tools.registry import ToolRegistry
 
@@ -44,7 +43,6 @@ class ReActLoop(BaseAgentLoop):
 
     reason_step: LLMStep
     act_step: ToolStep | None = None
-    memory: Memory | None = None
 
     async def stream(
         self,
@@ -76,7 +74,7 @@ class ReActLoop(BaseAgentLoop):
             llm_result: StepResult | None = None
 
             if loop_step == 1 and self.memory is not None:
-                await self._inject_memories(state, ctx)
+                await self._retrieve_memories(state, ctx)
 
             await self.hooks.run_before_model(state, ctx)
 
@@ -239,33 +237,6 @@ class ReActLoop(BaseAgentLoop):
                 f"Expected LLMOutput from structuring step, got {type(result.output).__name__}"
             )
         return result.output.raw
-
-    async def _inject_memories(
-        self, state: State, ctx: InvocationContext | None
-    ) -> None:
-        """Retrieve relevant memories and prepend them as Messages in state."""
-        user_query: str | None = next(
-            (m.content for m in reversed(state.messages) if m.role == "user"), ""
-        )
-        if not user_query:
-            return
-        if self.memory is None:
-            return
-        memory_msgs: list[Message] = await self.memory.retrieve(user_query, ctx=ctx)
-        state.messages[0:0] = memory_msgs
-
-    async def _consolidate_memories(
-        self,
-        messages: list[Message | None],
-        ctx: InvocationContext | None,
-    ) -> None:
-        """Persist the current-turn exchange to memory."""
-        to_store: list[Message] = [m for m in messages if m is not None and m.content]
-        if not to_store:
-            return
-        if self.memory is None:
-            return
-        await self.memory.update(to_store, ctx=ctx)
 
     def register_tool(self, registry: ToolRegistry) -> None:
         """Update internal steps to reflect a newly registered tool in registry."""

--- a/src/ant_ai/agent/loop/react.py
+++ b/src/ant_ai/agent/loop/react.py
@@ -133,7 +133,7 @@ class ReActLoop(BaseAgentLoop):
                         )
 
                 case FinalResponse():
-                    final_event = await self._make_final_answer(
+                    final_event: FinalAnswerEvent = await self._make_final_answer(
                         llm_result.output.raw, loop_step, coerce_schema, ctx
                     )
                     assistant_msg = Message(
@@ -176,7 +176,7 @@ class ReActLoop(BaseAgentLoop):
     ) -> FinalAnswerEvent:
         final_text: str = text
         if response_schema is not None:
-            final_text = await self._coerce_to_schema(text, response_schema, ctx)
+            final_text: str = await self._coerce_to_schema(text, response_schema, ctx)
 
         return FinalAnswerEvent(
             origin=EventOrigin(layer="agent", run_step=loop_step),
@@ -244,15 +244,14 @@ class ReActLoop(BaseAgentLoop):
         self, state: State, ctx: InvocationContext | None
     ) -> None:
         """Retrieve relevant memories and prepend them as Messages in state."""
-        user_query = next(
+        user_query: str | None = next(
             (m.content for m in reversed(state.messages) if m.role == "user"), ""
         )
         if not user_query:
             return
         if self.memory is None:
             return
-        run_id = ctx.session_id if ctx else None
-        memory_msgs = await self.memory.retrieve(user_query, run_id=run_id)
+        memory_msgs: list[Message] = await self.memory.retrieve(user_query, ctx=ctx)
         state.messages[0:0] = memory_msgs
 
     async def _consolidate_memories(
@@ -261,16 +260,15 @@ class ReActLoop(BaseAgentLoop):
         ctx: InvocationContext | None,
     ) -> None:
         """Persist the current-turn exchange to memory."""
-        to_store = [m for m in messages if m is not None and m.content]
+        to_store: list[Message] = [m for m in messages if m is not None and m.content]
         if not to_store:
             return
         if self.memory is None:
             return
-        run_id = ctx.session_id if ctx else None
-        await self.memory.update(to_store, run_id=run_id)
+        await self.memory.update(to_store, ctx=ctx)
 
     def register_tool(self, registry: ToolRegistry) -> None:
         """Update internal steps to reflect a newly registered tool in registry."""
-        self.reason_step.serialized_tools = registry.to_serialized()
+        self.reason_step.serialized_tools: list[dict] = registry.to_serialized()
         if self.act_step is None:
             self.act_step = ToolStep(registry=registry)

--- a/src/ant_ai/agent/loop/react.py
+++ b/src/ant_ai/agent/loop/react.py
@@ -22,6 +22,7 @@ from ant_ai.core.result import (
 )
 from ant_ai.core.types import InvocationContext, State
 from ant_ai.hooks import WrapCall
+from ant_ai.memory.protocol import Memory
 from ant_ai.steps import LLMStep, ToolStep
 from ant_ai.tools.registry import ToolRegistry
 
@@ -43,6 +44,7 @@ class ReActLoop(BaseAgentLoop):
 
     reason_step: LLMStep
     act_step: ToolStep | None = None
+    memory: Memory | None = None
 
     async def stream(
         self,
@@ -61,8 +63,20 @@ class ReActLoop(BaseAgentLoop):
             response_schema if self.act_step is not None else None
         )
 
+        _trigger_msg: Message | None = next(
+            (
+                m
+                for m in reversed(state.messages)
+                if isinstance(m, Message) and m.role == "user"
+            ),
+            None,
+        )
+
         for loop_step in range(1, max_steps + 1):
             llm_result: StepResult | None = None
+
+            if loop_step == 1 and self.memory is not None:
+                await self._inject_memories(state, ctx)
 
             await self.hooks.run_before_model(state, ctx)
 
@@ -122,12 +136,19 @@ class ReActLoop(BaseAgentLoop):
                     final_event = await self._make_final_answer(
                         llm_result.output.raw, loop_step, coerce_schema, ctx
                     )
-                    state.add_message(
-                        Message(role="assistant", content=final_event.content)
+                    assistant_msg = Message(
+                        role="assistant", content=final_event.content
                     )
+                    state.add_message(assistant_msg)
                     yield final_event
+                    if self.memory is not None:
+                        await self._consolidate_memories(
+                            [_trigger_msg, assistant_msg], ctx
+                        )
                     return
 
+        if self.memory is not None:
+            await self._consolidate_memories([_trigger_msg], ctx)
         yield MaxStepsReachedEvent(
             origin=EventOrigin(layer="agent", run_step=max_steps),
         )
@@ -218,6 +239,35 @@ class ReActLoop(BaseAgentLoop):
                 f"Expected LLMOutput from structuring step, got {type(result.output).__name__}"
             )
         return result.output.raw
+
+    async def _inject_memories(
+        self, state: State, ctx: InvocationContext | None
+    ) -> None:
+        """Retrieve relevant memories and prepend them as Messages in state."""
+        user_query = next(
+            (m.content for m in reversed(state.messages) if m.role == "user"), ""
+        )
+        if not user_query:
+            return
+        if self.memory is None:
+            return
+        run_id = ctx.session_id if ctx else None
+        memory_msgs = await self.memory.retrieve(user_query, run_id=run_id)
+        state.messages[0:0] = memory_msgs
+
+    async def _consolidate_memories(
+        self,
+        messages: list[Message | None],
+        ctx: InvocationContext | None,
+    ) -> None:
+        """Persist the current-turn exchange to memory."""
+        to_store = [m for m in messages if m is not None and m.content]
+        if not to_store:
+            return
+        if self.memory is None:
+            return
+        run_id = ctx.session_id if ctx else None
+        await self.memory.update(to_store, run_id=run_id)
 
     def register_tool(self, registry: ToolRegistry) -> None:
         """Update internal steps to reflect a newly registered tool in registry."""

--- a/src/ant_ai/core/types.py
+++ b/src/ant_ai/core/types.py
@@ -15,6 +15,7 @@ class InvocationContext(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     session_id: str
+    user_id: str | None = Field(default=None)
     llm_settings: dict[str, Any] | None = Field(default=None)
     workflow_settings: dict[str, Any] | None = Field(default=None)
 

--- a/src/ant_ai/memory/__init__.py
+++ b/src/ant_ai/memory/__init__.py
@@ -1,0 +1,3 @@
+from ant_ai.memory.protocol import Memory
+
+__all__ = ["Memory"]

--- a/src/ant_ai/memory/backends/mem0.py
+++ b/src/ant_ai/memory/backends/mem0.py
@@ -2,72 +2,75 @@ from __future__ import annotations
 
 from typing import Any
 
-from mem0 import AsyncMemory
-from pydantic import PrivateAttr
+from mem0 import AsyncMemoryClient
+from mem0.client.types import SearchMemoryOptions
+from pydantic import Field, PrivateAttr, model_validator
 
 from ant_ai.core.message import Message
 from ant_ai.core.types import InvocationContext
 from ant_ai.memory.protocol import Memory
 
 
-def _extract_run_id(kwargs: dict[str, Any]) -> str | None:
-    """Pop ctx (or run_id) from kwargs and return the resolved run_id."""
+def _resolve_ctx(kwargs: dict[str, Any]) -> dict[str, str]:
+    """Pop ctx (or bare entity ids) from kwargs and return mem0 filters dict.
+
+    ctx.user_id  → user_id  (cross-session)
+    ctx.session_id → run_id (session-scoped fallback)
+    """
     ctx: InvocationContext | None = kwargs.pop("ctx", None)
     if ctx is not None:
-        return ctx.session_id
-    return kwargs.pop("run_id", None)
+        if ctx.user_id:
+            return {"user_id": ctx.user_id}
+        return {"run_id": ctx.session_id}
+    filters: dict[str, str] = {}
+    for key in ("user_id", "run_id", "agent_id", "app_id"):
+        val = kwargs.pop(key, None)
+        if val is not None:
+            filters[key] = val
+    return filters
 
 
 class Mem0Memory(Memory):
     """
-    mem0 backend for AgentMemory.
+    mem0 cloud backend for AgentMemory.
 
-    Entity identifiers (user_id, agent_id, run_id, app_id) are NOT stored
-    on the instance — pass them at call time via **kwargs, exactly as mem0's
-    own API expects.
+    Requires MEM0_API_KEY in the environment, or pass ``api_key`` explicitly.
 
     Example::
 
-        memory = Mem0Memory()
-        msgs = await memory.retrieve("user preferences", filters={"user_id": "alice"})
-        await memory.update(conversation, user_id="alice", run_id="session-42")
+        memory = Mem0Memory(api_key="m0-...")
+        msgs = await memory.retrieve("user preferences", user_id="alice")
+        await memory.update(conversation, user_id="alice")
     """
 
-    _client: Any = PrivateAttr(default=AsyncMemory)
+    api_key: str | None = Field(default=None)
+    _client: Any = PrivateAttr()
+
+    @model_validator(mode="after")
+    def _init_client(self) -> Mem0Memory:
+        self._client = (
+            AsyncMemoryClient(api_key=self.api_key)
+            if self.api_key
+            else AsyncMemoryClient()
+        )
+        return self
 
     async def retrieve(
         self, query: str, *, top_k: int = 5, **kwargs: Any
     ) -> list[Message]:
-        """
-        Search mem0 and return results as system Messages.
-
-        Pass entity filters via kwargs, e.g.::
-
-            await memory.retrieve(query, filters={"user_id": "alice"})
-        """
-        run_id: str | None = _extract_run_id(kwargs)
-        if run_id is not None:
-            kwargs["run_id"] = run_id
-        results: Any = await self._client.search(query, top_k=top_k, **kwargs)
+        filters = _resolve_ctx(kwargs)
+        options = SearchMemoryOptions(filters=filters or None, top_k=top_k)
+        results: Any = await self._client.search(query, options=options)
         return [
             Message(role="system", content=r["memory"])
             for r in results.get("results", [])
         ]
 
     async def update(self, messages: list[Message], **kwargs: Any) -> None:
-        """
-        Add the conversation to mem0 for memory extraction.
-
-        Pass entity identifiers via kwargs, e.g.::
-
-            await memory.update(messages, user_id="alice", run_id="session-42")
-        """
-        run_id: str | None = _extract_run_id(kwargs)
-        if run_id is not None:
-            kwargs["run_id"] = run_id
+        filters = _resolve_ctx(kwargs)
         msg_dicts: list[dict[str, str]] = [
             {"role": m.role, "content": m.content} for m in messages if m.content
         ]
         if not msg_dicts:
             return
-        await self._client.add(msg_dicts, **kwargs)
+        await self._client.add(msg_dicts, **filters)

--- a/src/ant_ai/memory/backends/mem0.py
+++ b/src/ant_ai/memory/backends/mem0.py
@@ -6,7 +6,16 @@ from mem0 import AsyncMemory
 from pydantic import PrivateAttr
 
 from ant_ai.core.message import Message
+from ant_ai.core.types import InvocationContext
 from ant_ai.memory.protocol import Memory
+
+
+def _extract_run_id(kwargs: dict[str, Any]) -> str | None:
+    """Pop ctx (or run_id) from kwargs and return the resolved run_id."""
+    ctx: InvocationContext | None = kwargs.pop("ctx", None)
+    if ctx is not None:
+        return ctx.session_id
+    return kwargs.pop("run_id", None)
 
 
 class Mem0Memory(Memory):
@@ -36,6 +45,9 @@ class Mem0Memory(Memory):
 
             await memory.retrieve(query, filters={"user_id": "alice"})
         """
+        run_id: str | None = _extract_run_id(kwargs)
+        if run_id is not None:
+            kwargs["run_id"] = run_id
         results: Any = await self._client.search(query, top_k=top_k, **kwargs)
         return [
             Message(role="system", content=r["memory"])
@@ -50,6 +62,9 @@ class Mem0Memory(Memory):
 
             await memory.update(messages, user_id="alice", run_id="session-42")
         """
+        run_id: str | None = _extract_run_id(kwargs)
+        if run_id is not None:
+            kwargs["run_id"] = run_id
         msg_dicts: list[dict[str, str]] = [
             {"role": m.role, "content": m.content} for m in messages if m.content
         ]

--- a/src/ant_ai/memory/backends/mem0.py
+++ b/src/ant_ai/memory/backends/mem0.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mem0 import AsyncMemory
+from pydantic import PrivateAttr
+
+from ant_ai.core.message import Message
+from ant_ai.memory.protocol import Memory
+
+
+class Mem0Memory(Memory):
+    """
+    mem0 backend for AgentMemory.
+
+    Entity identifiers (user_id, agent_id, run_id, app_id) are NOT stored
+    on the instance — pass them at call time via **kwargs, exactly as mem0's
+    own API expects.
+
+    Example::
+
+        memory = Mem0Memory()
+        msgs = await memory.retrieve("user preferences", filters={"user_id": "alice"})
+        await memory.update(conversation, user_id="alice", run_id="session-42")
+    """
+
+    _client: Any = PrivateAttr(default=AsyncMemory)
+
+    async def retrieve(
+        self, query: str, *, top_k: int = 5, **kwargs: Any
+    ) -> list[Message]:
+        """
+        Search mem0 and return results as system Messages.
+
+        Pass entity filters via kwargs, e.g.::
+
+            await memory.retrieve(query, filters={"user_id": "alice"})
+        """
+        results: Any = await self._client.search(query, top_k=top_k, **kwargs)
+        return [
+            Message(role="system", content=r["memory"])
+            for r in results.get("results", [])
+        ]
+
+    async def update(self, messages: list[Message], **kwargs: Any) -> None:
+        """
+        Add the conversation to mem0 for memory extraction.
+
+        Pass entity identifiers via kwargs, e.g.::
+
+            await memory.update(messages, user_id="alice", run_id="session-42")
+        """
+        msg_dicts: list[dict[str, str]] = [
+            {"role": m.role, "content": m.content} for m in messages if m.content
+        ]
+        if not msg_dicts:
+            return
+        await self._client.add(msg_dicts, **kwargs)

--- a/src/ant_ai/memory/protocol.py
+++ b/src/ant_ai/memory/protocol.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from ant_ai.core.message import Message
+
+
+class Memory(BaseModel):
+    """
+    Pluggable memory interface for agents.
+
+    Implement `retrieve` and `update` to connect any memory backend.
+    Both methods accept `**kwargs` so callers can pass backend-specific
+    parameters (e.g. mem0's `user_id`, `filters`, `run_id`) without
+    changing the interface.
+    """
+
+    async def retrieve(
+        self, query: str, *, top_k: int = 5, **kwargs: Any
+    ) -> list[Message]:
+        """Return relevant memories as Messages, ready to inject into agent state."""
+        raise NotImplementedError
+
+    async def update(self, messages: list[Message], **kwargs: Any) -> None:
+        """Persist new knowledge from the current session."""
+        raise NotImplementedError

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from collections.abc import AsyncGenerator
+
+import pytest
+import uvicorn
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
+from sse_starlette.sse import AppStatus, _get_shutdown_state
+
+from ant_ai.a2a.colony import Colony
+from ant_ai.agent.agent import Agent
+from ant_ai.core.types import InvocationContext, State
+from ant_ai.llm.integrations.lite_llm import LiteLLMChat
+from ant_ai.memory.backends.mem0 import Mem0Memory
+from ant_ai.workflow.workflow import END, START, NodeYield, Workflow
+
+_MODEL = os.environ.get("MODEL", "gpt-5-mini")
+
+
+def _bound_socket() -> socket.socket:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", 0))
+    s.listen(128)
+    return s
+
+
+async def _start_server(
+    app, sock: socket.socket
+) -> tuple[uvicorn.Server, asyncio.Task]:
+    config = uvicorn.Config(app=app, log_level="warning", lifespan="off")
+    server = uvicorn.Server(config)
+    task: asyncio.Task = asyncio.create_task(server.serve(sockets=[sock]))
+    for _ in range(40):
+        if server.started:
+            break
+        await asyncio.sleep(0.05)
+    else:
+        task.cancel()
+        raise RuntimeError(f"Server on {sock.getsockname()} did not start within 2 s")
+    return server, task
+
+
+async def _stop_server(server: uvicorn.Server, task: asyncio.Task) -> None:
+    server.should_exit = True
+    await task
+    state = _get_shutdown_state()
+    for _ in range(20):
+        if not state.watcher_started:
+            break
+        await asyncio.sleep(0.05)
+    AppStatus.should_exit = False
+
+
+async def _run_agent_once(
+    agent: Agent,
+    state: State,
+    ctx: InvocationContext | None,
+) -> AsyncGenerator[NodeYield]:
+    async for event in agent.stream(state, ctx=ctx):
+        yield event
+    yield state
+
+
+def _make_workflow() -> Workflow:
+    wf = Workflow()
+    wf.add_node("run", _run_agent_once)
+    wf.add_edge(START, "run")
+    wf.add_edge("run", END)
+    return wf
+
+
+def _make_card(port: int) -> AgentCard:
+    card = AgentCard(
+        name="memory-agent",
+        description="An agent with persistent mem0 memory",
+        version="1.0.0",
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        capabilities=AgentCapabilities(streaming=True),
+    )
+    card.supported_interfaces.append(
+        AgentInterface(protocol_binding="JSONRPC", url=f"http://127.0.0.1:{port}/")
+    )
+    card.skills.append(
+        AgentSkill(id="chat", name="chat", description="Chat with memory")
+    )
+    return card
+
+
+@pytest.fixture
+async def memory_agent_server() -> AsyncGenerator[dict]:
+    """Colony server with Mem0Memory on a free port. Yields {"url", "user_id"}."""
+    import uuid
+
+    user_id = f"test-{uuid.uuid4().hex[:8]}"
+    sock = _bound_socket()
+    port = sock.getsockname()[1]
+
+    agent = Agent(
+        name="memory-agent",
+        llm=LiteLLMChat(_MODEL),
+        system_prompt=(
+            "You are a helpful assistant with persistent memory. "
+            "Use what you know about the user to give personalised responses."
+        ),
+        description="An agent with persistent mem0 memory",
+        memory=Mem0Memory(),
+    )
+    colony = Colony()
+    colony.agent(
+        "memory-agent",
+        agent=agent,
+        workflow=_make_workflow(),
+        card=_make_card(port),
+    )
+    app = colony.asgi(agent_name="memory-agent", use_fastapi=True)
+
+    server, task = await _start_server(app, sock)
+    yield {"url": f"http://127.0.0.1:{port}/", "user_id": user_id}
+    await _stop_server(server, task)

--- a/tests/integration/memory/test_mem0.py
+++ b/tests/integration/memory/test_mem0.py
@@ -1,15 +1,6 @@
-"""
-Integration tests for Mem0Memory.
-
-Requires:
-- mem0ai installed: pip install 'ant-ai[mem0]'
-- MEM0_API_KEY set in the environment (or .env)
-
-Run with: uv run pytest tests/integration/memory/ -m external
-"""
-
 from __future__ import annotations
 
+import asyncio
 import uuid
 
 import pytest
@@ -18,38 +9,64 @@ from ant_ai.core.message import Message
 from ant_ai.memory.backends.mem0 import Mem0Memory
 
 
+async def _poll(
+    memory: Mem0Memory,
+    query: str,
+    keyword: str,
+    *,
+    timeout: int = 30,
+    interval: int = 3,
+    **kwargs,
+) -> str:
+    """Poll retrieve() until keyword appears in results or timeout expires."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        results = await memory.retrieve(query, **kwargs)
+        contents = " ".join(m.content for m in results).lower()
+        if keyword in contents:
+            return contents
+        await asyncio.sleep(interval)
+    return ""
+
+
 @pytest.mark.external
+@pytest.mark.mem0
 async def test_mem0_update_and_retrieve_roundtrip():
     """update() stores a fact; retrieve() returns it in a subsequent search."""
-    run_id = f"test-{uuid.uuid4()}"
+    user_id = f"test-{uuid.uuid4()}"
     memory = Mem0Memory()
 
-    messages = [
-        Message(role="user", content="My favourite programming language is Rust."),
-        Message(
-            role="assistant", content="Got it, I'll remember that you prefer Rust."
-        ),
-    ]
-    await memory.update(messages, run_id=run_id)
+    await memory.update(
+        [
+            Message(role="user", content="My favourite programming language is Rust."),
+            Message(
+                role="assistant", content="Got it, I'll remember that you prefer Rust."
+            ),
+        ],
+        user_id=user_id,
+    )
 
-    results = await memory.retrieve("programming language preference", run_id=run_id)
-
-    contents = " ".join(m.content for m in results).lower()
-    assert "rust" in contents, f"Expected 'rust' in retrieved memories, got: {contents}"
+    contents = await _poll(
+        memory, "programming language preference", "rust", user_id=user_id
+    )
+    assert "rust" in contents, (
+        f"Expected 'rust' in retrieved memories, got: {contents!r}"
+    )
 
 
 @pytest.mark.external
+@pytest.mark.mem0
 async def test_mem0_retrieve_returns_messages():
     """retrieve() always returns a list of Message objects with role='system'."""
-    run_id = f"test-{uuid.uuid4()}"
+    user_id = f"test-{uuid.uuid4()}"
     memory = Mem0Memory()
 
     await memory.update(
         [Message(role="user", content="I live in Zurich.")],
-        run_id=run_id,
+        user_id=user_id,
     )
 
-    results = await memory.retrieve("location", run_id=run_id)
+    results = await memory.retrieve("location", user_id=user_id)
 
     assert isinstance(results, list)
     for msg in results:
@@ -59,11 +76,12 @@ async def test_mem0_retrieve_returns_messages():
 
 
 @pytest.mark.external
+@pytest.mark.mem0
 async def test_mem0_empty_retrieve_returns_empty_list():
-    """retrieve() returns [] when no relevant memories exist for the run."""
-    run_id = f"empty-{uuid.uuid4()}"
+    """retrieve() returns [] when no relevant memories exist for the user."""
+    user_id = f"empty-{uuid.uuid4()}"
     memory = Mem0Memory()
 
-    results = await memory.retrieve("anything", run_id=run_id)
+    results = await memory.retrieve("anything", user_id=user_id)
 
     assert results == []

--- a/tests/integration/memory/test_mem0.py
+++ b/tests/integration/memory/test_mem0.py
@@ -1,0 +1,69 @@
+"""
+Integration tests for Mem0Memory.
+
+Requires:
+- mem0ai installed: pip install 'ant-ai[mem0]'
+- MEM0_API_KEY set in the environment (or .env)
+
+Run with: uv run pytest tests/integration/memory/ -m external
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from ant_ai.core.message import Message
+from ant_ai.memory.backends.mem0 import Mem0Memory
+
+
+@pytest.mark.external
+async def test_mem0_update_and_retrieve_roundtrip():
+    """update() stores a fact; retrieve() returns it in a subsequent search."""
+    run_id = f"test-{uuid.uuid4()}"
+    memory = Mem0Memory()
+
+    messages = [
+        Message(role="user", content="My favourite programming language is Rust."),
+        Message(
+            role="assistant", content="Got it, I'll remember that you prefer Rust."
+        ),
+    ]
+    await memory.update(messages, run_id=run_id)
+
+    results = await memory.retrieve("programming language preference", run_id=run_id)
+
+    contents = " ".join(m.content for m in results).lower()
+    assert "rust" in contents, f"Expected 'rust' in retrieved memories, got: {contents}"
+
+
+@pytest.mark.external
+async def test_mem0_retrieve_returns_messages():
+    """retrieve() always returns a list of Message objects with role='system'."""
+    run_id = f"test-{uuid.uuid4()}"
+    memory = Mem0Memory()
+
+    await memory.update(
+        [Message(role="user", content="I live in Zurich.")],
+        run_id=run_id,
+    )
+
+    results = await memory.retrieve("location", run_id=run_id)
+
+    assert isinstance(results, list)
+    for msg in results:
+        assert isinstance(msg, Message)
+        assert msg.role == "system"
+        assert msg.content
+
+
+@pytest.mark.external
+async def test_mem0_empty_retrieve_returns_empty_list():
+    """retrieve() returns [] when no relevant memories exist for the run."""
+    run_id = f"empty-{uuid.uuid4()}"
+    memory = Mem0Memory()
+
+    results = await memory.retrieve("anything", run_id=run_id)
+
+    assert results == []

--- a/tests/integration/memory/test_memory_agent.py
+++ b/tests/integration/memory/test_memory_agent.py
@@ -1,0 +1,66 @@
+"""
+End-to-end memory integration test.
+
+Starts a Colony server backed by Mem0Memory and fires two A2A turns:
+  1. Store a fact about the user.
+  2. New session, same user_id — agent must recall the fact.
+
+Note: mem0 user_id memory extraction is async on their end (~5-7 s to index).
+The test sleeps between turns to let indexing complete.
+
+Requires:
+    OPENAI_API_KEY and MEM0_API_KEY set in environment or .env
+
+Run:
+    uv run pytest tests/integration/memory/test_memory_agent.py -m "integration and mem0"
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ant_ai.a2a.client import A2AClient
+from ant_ai.a2a.config import A2AConfig
+from ant_ai.core.events import Event, FinalAnswerEvent
+
+
+async def _send(client: A2AClient, message: str, user_id: str) -> str:
+    events: list[Event] = [
+        ev
+        async for ev in client.send_message(
+            message,
+            request_metadata={"user_id": user_id},
+        )
+    ]
+    final: FinalAnswerEvent | None = next(
+        (ev for ev in events if isinstance(ev, FinalAnswerEvent)), None
+    )
+    return final.content if final else ""
+
+
+@pytest.mark.integration
+@pytest.mark.mem0
+@pytest.mark.external
+async def test_memory_agent_recalls_preference_across_sessions(
+    memory_agent_server: dict,
+) -> None:
+    """Agent stores a fact in turn 1 and recalls it in a fresh session (turn 2)."""
+    url = memory_agent_server["url"]
+    user_id = memory_agent_server["user_id"]
+
+    async with A2AClient(config=A2AConfig(endpoint=url)) as client:
+        await _send(client, "My favourite language is Rust.", user_id)
+
+    # mem0 user_id-scoped memory extraction is async — indexing takes ~5-7 s.
+    await asyncio.sleep(10)
+
+    async with A2AClient(config=A2AConfig(endpoint=url)) as client:
+        response = await _send(
+            client, "What is my favourite programming language?", user_id
+        )
+
+    assert "rust" in response.lower(), (
+        f"Expected agent to recall 'rust' from memory, got: {response!r}"
+    )

--- a/tests/integration/memory/test_memory_agent.py
+++ b/tests/integration/memory/test_memory_agent.py
@@ -1,20 +1,3 @@
-"""
-End-to-end memory integration test.
-
-Starts a Colony server backed by Mem0Memory and fires two A2A turns:
-  1. Store a fact about the user.
-  2. New session, same user_id — agent must recall the fact.
-
-Note: mem0 user_id memory extraction is async on their end (~5-7 s to index).
-The test sleeps between turns to let indexing complete.
-
-Requires:
-    OPENAI_API_KEY and MEM0_API_KEY set in environment or .env
-
-Run:
-    uv run pytest tests/integration/memory/test_memory_agent.py -m "integration and mem0"
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit/memory/conftest.py
+++ b/tests/unit/memory/conftest.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import Field, PrivateAttr
+
+from ant_ai.core.message import Message
+from ant_ai.memory.protocol import Memory
+
+
+class StubMemory(Memory):
+    retrieve_calls: list[dict] = Field(default_factory=list)
+    update_calls: list[dict] = Field(default_factory=list)
+    _fixed_entries: list[Message] = PrivateAttr(default_factory=list)
+
+    def set_entries(self, entries: list[Message]) -> None:
+        self._fixed_entries = entries
+
+    async def retrieve(
+        self, query: str, *, top_k: int = 5, **kwargs: Any
+    ) -> list[Message]:
+        self.retrieve_calls.append({"query": query, "top_k": top_k, **kwargs})
+        return list(self._fixed_entries)
+
+    async def update(self, messages: list[Message], **kwargs: Any) -> None:
+        self.update_calls.append({"messages": list(messages), **kwargs})
+
+
+@pytest.fixture
+def stub_memory() -> StubMemory:
+    return StubMemory()

--- a/tests/unit/memory/test_react_loop_memory.py
+++ b/tests/unit/memory/test_react_loop_memory.py
@@ -198,8 +198,8 @@ async def test_kwargs_forwarded_to_retrieve_and_update(stub_memory):
 
     [_ async for _ in loop.stream(state, ctx=ctx)]
 
-    assert stub_memory.retrieve_calls[0].get("run_id") == "sess-123"
-    assert stub_memory.update_calls[0].get("run_id") == "sess-123"
+    assert stub_memory.retrieve_calls[0].get("ctx") is ctx
+    assert stub_memory.update_calls[0].get("ctx") is ctx
 
 
 @pytest.mark.unit

--- a/tests/unit/memory/test_react_loop_memory.py
+++ b/tests/unit/memory/test_react_loop_memory.py
@@ -203,6 +203,48 @@ async def test_kwargs_forwarded_to_retrieve_and_update(stub_memory):
 
 
 @pytest.mark.unit
+async def test_update_called_when_consumer_breaks_after_final_event(stub_memory):
+    """update() must fire even if the caller stops iterating after FinalAnswerEvent."""
+    from ant_ai.core.events import FinalAnswerEvent
+
+    reason_step = FakeStep("llm", [make_llm_result("the answer")])
+    loop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="user", content="q")])
+
+    # Simulate a consumer that exits as soon as it sees FinalAnswerEvent —
+    # the regression was that memory.update() was placed after the yield,
+    # so an early-exit caller would never trigger it.
+    async for event in loop.stream(state, ctx=None):
+        if isinstance(event, FinalAnswerEvent):
+            break
+
+    assert len(stub_memory.update_calls) == 1, (
+        "update() must be called before FinalAnswerEvent is yielded so that "
+        "consumers that break early still persist memory"
+    )
+
+
+@pytest.mark.unit
+async def test_update_called_before_final_event_is_yielded(stub_memory):
+    """Memory consolidation happens before FinalAnswerEvent is emitted."""
+    from ant_ai.core.events import FinalAnswerEvent
+
+    update_call_count_at_event: list[int] = []
+
+    reason_step = FakeStep("llm", [make_llm_result("ans")])
+    loop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="user", content="q")])
+
+    async for event in loop.stream(state, ctx=None):
+        if isinstance(event, FinalAnswerEvent):
+            update_call_count_at_event.append(len(stub_memory.update_calls))
+
+    assert update_call_count_at_event == [1], (
+        "update() must have been called before FinalAnswerEvent reaches the consumer"
+    )
+
+
+@pytest.mark.unit
 async def test_retrieve_called_only_once_across_multiple_loop_steps(stub_memory):
     """retrieve() fires before the first model step only — not on subsequent steps."""
     from ant_ai.core.message import ToolCall, ToolFunction

--- a/tests/unit/memory/test_react_loop_memory.py
+++ b/tests/unit/memory/test_react_loop_memory.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import pytest
+
+from ant_ai.agent.loop.react import ReActLoop
+from ant_ai.core.events import MaxStepsReachedEvent
+from ant_ai.core.message import Message
+from ant_ai.core.result import LLMOutput, StepResult, Transition, TransitionAction
+from ant_ai.core.types import InvocationContext, State
+from ant_ai.hooks import HookLayer
+from ant_ai.memory.protocol import Memory
+
+
+def make_llm_result(
+    text: str = "answer",
+    *,
+    action: TransitionAction = TransitionAction.END,
+) -> StepResult:
+    return StepResult(
+        output=LLMOutput(raw=text, tool_calls=()),
+        transition=Transition(action=action),
+    )
+
+
+class FakeStep:
+    def __init__(self, name: str, items: list):
+        self._name: str = name
+        self._items = list(items)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def run(self, state, ctx):
+        for item in self._items:
+            yield item
+
+
+def make_loop(reason_step, *, memory: Memory | None = None) -> ReActLoop:
+    return ReActLoop.model_construct(
+        reason_step=reason_step,
+        act_step=None,
+        hooks=HookLayer(),
+        max_retries=3,
+        memory=memory,
+    )
+
+
+@pytest.mark.unit
+async def test_retrieve_called_before_first_model_step(stub_memory):
+    """retrieve() is called exactly once, before the first LLM invocation."""
+    reason_step = FakeStep("llm", [make_llm_result("done")])
+    loop: ReActLoop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="user", content="hello")])
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+
+    assert len(stub_memory.retrieve_calls) == 1
+    assert stub_memory.retrieve_calls[0]["query"] == "hello"
+
+
+@pytest.mark.unit
+async def test_retrieved_messages_prepended_to_state(stub_memory):
+    """Messages returned by retrieve() are inserted at the start of state.messages."""
+    memory_msg = Message(role="system", content="User prefers Python")
+    stub_memory.set_entries([memory_msg])
+
+    reason_step = FakeStep("llm", [make_llm_result("done")])
+    loop: ReActLoop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="user", content="hi")])
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+
+    assert state.messages[0] == memory_msg
+
+
+@pytest.mark.unit
+async def test_retrieve_not_called_when_no_user_message(stub_memory):
+    """retrieve() is skipped when state has no user message."""
+    reason_step = FakeStep("llm", [make_llm_result("done")])
+    loop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="system", content="sys")])
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+
+    assert len(stub_memory.retrieve_calls) == 0
+
+
+@pytest.mark.unit
+async def test_update_called_on_final_response(stub_memory):
+    """update() is called once after a FinalResponse with trigger + assistant messages."""
+    reason_step = FakeStep("llm", [make_llm_result("final answer")])
+    loop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="user", content="q")])
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+
+    assert len(stub_memory.update_calls) == 1
+    stored = stub_memory.update_calls[0]["messages"]
+    roles = [m.role for m in stored]
+    assert "user" in roles
+    assert "assistant" in roles
+
+
+@pytest.mark.unit
+async def test_update_called_on_max_steps_reached(stub_memory):
+    """update() is called with at least the trigger message when max steps are exhausted."""
+    from ant_ai.core.message import ToolCall, ToolFunction
+    from ant_ai.core.result import ToolOutput
+
+    tool_call = ToolCall(
+        id="t1", function=ToolFunction(name="loop_tool", arguments="{}")
+    )
+
+    class AlwaysToolLLM:
+        name = "llm"
+
+        async def run(self, state, ctx):
+            yield StepResult(
+                output=LLMOutput(raw="calling tool", tool_calls=(tool_call,)),
+                transition=Transition(action=TransitionAction.CONTINUE),
+            )
+
+    class AlwaysContinueTool:
+        name = "tool"
+
+        async def run(self, state, ctx):
+            yield StepResult(
+                output=ToolOutput(
+                    results=[
+                        {"name": "loop_tool", "tool_call_id": "t1", "content": "ok"}
+                    ]
+                ),
+                transition=Transition(
+                    action=TransitionAction.CONTINUE, next_step="llm"
+                ),
+            )
+
+    loop = ReActLoop.model_construct(
+        reason_step=AlwaysToolLLM(),
+        act_step=AlwaysContinueTool(),
+        hooks=HookLayer(),
+        max_retries=3,
+        memory=stub_memory,
+    )
+    state = State(messages=[Message(role="user", content="loop forever")])
+
+    events = [e async for e in loop.stream(state, ctx=None, max_steps=2)]
+
+    assert any(isinstance(e, MaxStepsReachedEvent) for e in events)
+    assert len(stub_memory.update_calls) == 1
+    stored = stub_memory.update_calls[0]["messages"]
+    assert any(m.role == "user" for m in stored)
+
+
+@pytest.mark.unit
+async def test_no_memory_calls_when_memory_is_none():
+    """No retrieve or update calls are made when memory=None."""
+    reason_step = FakeStep("llm", [make_llm_result("ok")])
+    loop: ReActLoop = make_loop(reason_step, memory=None)
+    state = State(messages=[Message(role="user", content="hi")])
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+    # No assertions needed — if memory methods were called they'd raise AttributeError
+
+
+@pytest.mark.unit
+async def test_update_only_current_turn_in_multi_turn(stub_memory):
+    """In a multi-turn scenario, update() receives only the new exchange, not prior history."""
+    reason_step = FakeStep("llm", [make_llm_result("second answer")])
+    loop = make_loop(reason_step, memory=stub_memory)
+
+    state = State(
+        messages=[
+            Message(role="user", content="first question"),
+            Message(role="assistant", content="first answer"),
+            Message(role="user", content="second question"),
+        ]
+    )
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+
+    assert len(stub_memory.update_calls) == 1
+    stored_contents = [m.content for m in stub_memory.update_calls[0]["messages"]]
+    assert "first question" not in stored_contents
+    assert "first answer" not in stored_contents
+    assert "second question" in stored_contents
+    assert "second answer" in stored_contents
+
+
+@pytest.mark.unit
+async def test_kwargs_forwarded_to_retrieve_and_update(stub_memory):
+    """**kwargs passed via session context are forwarded to retrieve and update."""
+    reason_step = FakeStep("llm", [make_llm_result("ans")])
+    loop: ReActLoop = make_loop(reason_step, memory=stub_memory)
+    state = State(messages=[Message(role="user", content="q")])
+    ctx = InvocationContext(session_id="sess-123")
+
+    [_ async for _ in loop.stream(state, ctx=ctx)]
+
+    assert stub_memory.retrieve_calls[0].get("run_id") == "sess-123"
+    assert stub_memory.update_calls[0].get("run_id") == "sess-123"
+
+
+@pytest.mark.unit
+async def test_retrieve_called_only_once_across_multiple_loop_steps(stub_memory):
+    """retrieve() fires before the first model step only — not on subsequent steps."""
+    from ant_ai.core.message import ToolCall, ToolFunction
+    from ant_ai.core.result import ToolOutput
+
+    tool_call = ToolCall(id="t1", function=ToolFunction(name="my_tool", arguments="{}"))
+    tool_result = StepResult(
+        output=ToolOutput(
+            results=[{"name": "my_tool", "tool_call_id": "t1", "content": "ok"}]
+        ),
+        transition=Transition(action=TransitionAction.CONTINUE, next_step="llm"),
+    )
+
+    call_count = 0
+
+    class TwoStepLLM:
+        name = "llm"
+
+        async def run(self, state, ctx):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield StepResult(
+                    output=LLMOutput(raw="calling tool", tool_calls=(tool_call,)),
+                    transition=Transition(action=TransitionAction.CONTINUE),
+                )
+            else:
+                yield make_llm_result("done")
+
+    class FakeToolStep:
+        name = "tool"
+
+        async def run(self, state, ctx):
+            yield tool_result
+
+    loop: ReActLoop = ReActLoop.model_construct(
+        reason_step=TwoStepLLM(),
+        act_step=FakeToolStep(),
+        hooks=HookLayer(),
+        max_retries=3,
+        memory=stub_memory,
+    )
+    state = State(messages=[Message(role="user", content="use a tool")])
+
+    [_ async for _ in loop.stream(state, ctx=None)]
+
+    assert len(stub_memory.retrieve_calls) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-06T07:52:24.674443Z"
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -177,6 +177,9 @@ dependencies = [
 langfuse = [
     { name = "langfuse" },
 ]
+mem0 = [
+    { name = "mem0ai" },
+]
 openai = [
     { name = "openai" },
 ]
@@ -214,12 +217,13 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.83.10" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", specifier = ">=1.27.0" },
+    { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.24.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "starlette", specifier = ">=1.0.0" },
     { name = "uvicorn", specifier = ">=0.44.0" },
 ]
-provides-extras = ["langfuse", "openai", "viz"]
+provides-extras = ["langfuse", "mem0", "openai", "viz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -836,6 +840,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -857,6 +874,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -887,6 +913,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -914,6 +945,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1179,6 +1219,24 @@ wheels = [
 ]
 
 [[package]]
+name = "mem0ai"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai" },
+    { name = "posthog" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "qdrant-client" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/03/3dc535b98310912e4f10083acdbbca2c5e2dfccb3921230a460464f9f4d0/mem0ai-2.0.1.tar.gz", hash = "sha256:070dbc3f1f332c8908379b42a81ab3a96ab169f2f9fa537e6ac719df02478f9c", size = 211820, upload-time = "2026-04-25T17:39:06.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/96/e6153262f1464f4d412208732fea31496d9983ade155dd2c5c5492f8f8a4/mem0ai-2.0.1-py3-none-any.whl", hash = "sha256:63da5f50ad0c2514e27c2f380ef03f2ceea47c97873096ddfd997785b58043ec", size = 299461, upload-time = "2026-04-25T17:39:04.143Z" },
+]
+
+[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1436,6 +1494,35 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1579,6 +1666,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/0f/0e6578feaf0d4e670bc517b6da09ec147a65421c44e0cd687eba12f08743/posthog-7.14.0.tar.gz", hash = "sha256:3be5e513f07e4ee5119f98b0458cb640739b49cef7c96c3e18b1d65076b18239", size = 205083, upload-time = "2026-05-01T20:41:37.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/c2/2dc3e08e481f45c0215da4325ccc9b5f368dcee504779d2f169ab567c766/posthog-7.14.0-py3-none-any.whl", hash = "sha256:76db6e3158e2c11ec9bbcf32a673efec4acc8078965d92e2d3055555220ee546", size = 240187, upload-time = "2026-05-01T20:41:36.022Z" },
 ]
 
 [[package]]
@@ -1915,6 +2029,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -1960,6 +2083,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/dd/f8a8261b83946af3cd65943c93c4f83e044f01184e8525404989d22a81a5/qdrant_client-1.17.1.tar.gz", hash = "sha256:22f990bbd63485ed97ba551a4c498181fcb723f71dcab5d6e4e43fe1050a2bc0", size = 344979, upload-time = "2026-03-13T17:13:44.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/69/77d1a971c4b933e8c79403e99bcbb790463da5e48333cc4fd5d412c63c98/qdrant_client-1.17.1-py3-none-any.whl", hash = "sha256:6cda4064adfeaf211c751f3fbc00edbbdb499850918c7aff4855a9a759d56cbd", size = 389947, upload-time = "2026-03-13T17:13:43.156Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & Why

Adds a pluggable `Memory` interface that agents can use to persist and retrieve cross-session context. The first backend is mem0 (cloud client). `user_id` is threaded through `InvocationContext` so the A2A executor and any caller can scope memory to a specific user.

## Changes

- Added `Memory` protocol (`src/ant_ai/memory/protocol.py`) — abstract `retrieve` / `update` interface backed by Pydantic `BaseModel`
- Added `Mem0Memory` backend (`src/ant_ai/memory/backends/mem0.py`) — uses `AsyncMemoryClient`; resolves `user_id` / `run_id` from `InvocationContext` via `_resolve_ctx`
- Added `memory: Memory | None` field to `BaseAgent` and `BaseAgentLoop`
- Added `_retrieve_memories` / `_consolidate_memories` helpers to `BaseAgentLoop`; wired into `ReActLoop` (retrieve on step 1, consolidate on final answer or max-steps)
- Added `user_id` field to `InvocationContext` and wired it through `A2AExecutor` from `context.metadata`
- Added unit tests (`tests/unit/memory/`) and integration tests (`tests/integration/memory/`) with fixtures and markers
- Exported `Memory` from `ant_ai.__init__`

## Closes

Closes #27

## Release

- [ ] `bump:patch` — bug fix
- [x] `bump:minor` — new functionality
- [ ] `bump:major` — breaking change

## Docs

`Memory`, `Mem0Memory`, and the `memory` field on `BaseAgent` are documented via docstrings.