### PR TITLE
ci(release): add workflow_dispatch trigger with bump_type input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,26 @@ on:
     pull_request:
         types: [closed]
         branches: [main]
+    workflow_dispatch:
+        inputs:
+            bump_type:
+                description: "Version bump type"
+                required: true
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
 
 jobs:
     release:
         if: >-
-            github.event.pull_request.merged == true && (
-              contains(github.event.pull_request.labels.*.name, 'bump:patch') ||
-              contains(github.event.pull_request.labels.*.name, 'bump:minor') ||
-              contains(github.event.pull_request.labels.*.name, 'bump:major')
+            github.event_name == 'workflow_dispatch' || (
+              github.event.pull_request.merged == true && (
+                contains(github.event.pull_request.labels.*.name, 'bump:patch') ||
+                contains(github.event.pull_request.labels.*.name, 'bump:minor') ||
+                contains(github.event.pull_request.labels.*.name, 'bump:major')
+              )
             )
         runs-on: ubuntu-latest
         permissions:
@@ -31,7 +43,9 @@ jobs:
             - name: Determine bump type
               id: bump
               run: |
-                  if ${{ contains(github.event.pull_request.labels.*.name, 'bump:major') }}; then
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    echo "type=${{ github.event.inputs.bump_type }}" >> $GITHUB_OUTPUT
+                  elif ${{ contains(github.event.pull_request.labels.*.name, 'bump:major') }}; then
                     echo "type=major" >> $GITHUB_OUTPUT
                   elif ${{ contains(github.event.pull_request.labels.*.name, 'bump:minor') }}; then
                     echo "type=minor" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What & Why

Adds a `workflow_dispatch` trigger to the release workflow so it can be manually triggered from the GitHub Actions UI — no need for a dummy PR when a label is missed on merge.

## Changes

- `workflow_dispatch` trigger with a `bump_type` input (`patch` / `minor` / `major`)
- Job condition extended to allow dispatch events through
- Bump type determination falls back to the input when triggered manually

## Release

- [ ] `bump:patch` — bug fix
- [x] `bump:minor` — new functionality
- [ ] `bump:major` — breaking change