### PR TITLE
chore(pre-commit): replace gitleaks with betterleaks v1.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
             args: [--fix]
           - id: ruff-format
 
-    - repo: https://github.com/gitleaks/gitleaks
-      rev: v8.30.0
+    - repo: https://github.com/betterleaks/betterleaks
+      rev: v1.4.0
       hooks:
-          - id: gitleaks
+          - id: betterleaks


### PR DESCRIPTION
## What & Why

Replaces the `gitleaks` pre-commit hook with `betterleaks` v1.4.0, a modernised drop-in replacement by the same author.

## Changes

- Updated `.pre-commit-config.yaml`: swapped `github.com/gitleaks/gitleaks` (rev `v8.30.0`) for `github.com/betterleaks/betterleaks` (rev `v1.4.0`) and updated the hook id accordingly

## Closes

Closes #53

## Release

No release needed — tooling/config change only.