### PR TITLE
refactor(events): add tool_calls field to ToolCallingEvent

### DIFF
--- a/docs/docs/architecture/index.md
+++ b/docs/docs/architecture/index.md
@@ -169,7 +169,7 @@ Emitted by the agent's ReAct loop during LLM calls and tool execution.
 | Class                                                                     | `kind`                | When emitted                                                                                                   |
 | ------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------- |
 | [`ReasoningEvent`][ant_ai.core.events.ReasoningEvent]                     | `"reasoning"`         | Model produced extended thinking / reasoning text (before the answer)                                          |
-| [`ToolCallingEvent`][ant_ai.core.events.ToolCallingEvent]                 | `"tool_calling"`      | LLM response contains tool calls; `message` holds the [`ToolCallMessage`][ant_ai.core.message.ToolCallMessage] |
+| [`ToolCallingEvent`][ant_ai.core.events.ToolCallingEvent]                 | `"tool_calling"`      | LLM response contains tool calls; `tool_calls` holds the requested [`ToolCall`][ant_ai.core.message.ToolCall] items |
 | [`ToolResultEvent`][ant_ai.core.events.ToolResultEvent]                   | `"tool_result"`       | One tool call completed; `content` holds the result                                                            |
 | [`FinalAnswerEvent`][ant_ai.core.events.FinalAnswerEvent]                 | `"final_answer"`      | LLM produced a plain-text response (no tool calls); ends the ReAct loop                                        |
 | [`MaxStepsReachedEvent`][ant_ai.core.events.MaxStepsReachedEvent]         | `"max_steps_reached"` | Agent exhausted its maximum allowed ReAct steps                                                                |
@@ -193,7 +193,7 @@ async for event in workflow.stream(agent, ctx=ctx, state=state):
         case ReasoningEvent():
             print("thinking:", event.content)
         case ToolCallingEvent():
-            print("calling tools:", event.message)
+            print("calling tools:", event.tool_calls)
         case ToolResultEvent():
             print("tool result:", event.content)
         case FinalAnswerEvent():

--- a/docs/docs/single-agent/skills.md
+++ b/docs/docs/single-agent/skills.md
@@ -169,7 +169,7 @@ async def main():
 
     async for event in agent.stream(state, ctx=ctx):
         if isinstance(event, ToolCallingEvent):
-            for tc in event.message.tool_calls:
+            for tc in event.tool_calls:
                 print(f"[tool] {tc.function.name} {tc.function.arguments}")
         elif isinstance(event, FinalAnswerEvent):
             print(f"\n{event.content}")

--- a/src/ant_ai/core/events.py
+++ b/src/ant_ai/core/events.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
-from ant_ai.core.message import AnyMessage
+from ant_ai.core.message import AnyMessage, ToolCall
 
 type EventSource = Literal["agent", "action", "workflow"]
 """Sources where events are generated during a run."""
@@ -118,6 +118,10 @@ class ToolCallingEvent(AgentEvent):
     """Emitted when the agent decides to call one or more tools."""
 
     kind: Literal["tool_calling"] = "tool_calling"
+    tool_calls: tuple[ToolCall, ...] = Field(
+        default=(),
+        description="The tool calls requested by the model.",
+    )
 
 
 class ToolResultEvent(AgentEvent):

--- a/src/ant_ai/steps/llm_step.py
+++ b/src/ant_ai/steps/llm_step.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 
 from ant_ai.core.events import FinalAnswerEvent, ReasoningEvent, ToolCallingEvent
-from ant_ai.core.message import Message, ToolCall, ToolCallMessage
+from ant_ai.core.message import Message, ToolCall
 from ant_ai.core.response import ChatLLMResponse
 from ant_ai.core.result import (
     LLMOutput,
@@ -88,7 +88,7 @@ class LLMStep(BaseModel):
             transition = Transition(action=TransitionAction.CONTINUE, next_step="tool")
             event = ToolCallingEvent(
                 content=raw,
-                message=ToolCallMessage(tool_calls=tool_calls),
+                tool_calls=tuple(tool_calls),
             )
         else:
             transition = Transition(action=TransitionAction.END)


### PR DESCRIPTION
## Summary

- Adds `tool_calls: tuple[ToolCall, ...]` directly on `ToolCallingEvent`, making its payload consistent with all other events that expose data via a dedicated typed field
- Removes `message=ToolCallMessage(tool_calls=...)` from `LLMStep` construction — the polymorphic `message` field is no longer used as a payload carrier for this event
- Updates both doc examples that referenced `event.message` / `event.message.tool_calls`

Closes #24

## Test plan

- [x] All existing unit tests pass (`tests/unit/steps/`, `tests/unit/agent/`)
- [x] Pre-commit hooks pass (ruff lint, ruff format, secret detection)
- [x] Verified no code in the codebase reads `ToolCallingEvent.message` — A2A translator uses `event.content`, history reconstruction is unaffected
- [x] Docs updated: `architecture/index.md` event table and consuming-events example, `single-agent/skills.md` usage example

🤖 Generated with [Claude Code](https://claude.com/claude-code)