### PR TITLE
chore: update homepage and docs URLs to idea.idsia.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![License](https://img.shields.io/badge/License-MIT-green)
 ![PyPI - Version](https://img.shields.io/pypi/v/ant-ai?label=PyPI)
 [![Coverage](https://img.shields.io/codecov/c/github/idea-idsia/ant-ai?label=Coverage&logo=codecov)](https://codecov.io/gh/idea-idsia/ant-ai)
-[![Docs](https://img.shields.io/badge/Docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://idea-idsia.github.io/ant-ai/)
+[![Docs](https://img.shields.io/badge/Docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://idea.idsia.ch/ant-ai/)
 
 **A lightweight Python framework for building tool-driven AI agents and multi-agent systems.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://idea-idsia.github.io/ant-ai/"
-Documentation = "https://idea-idsia.github.io/ant-ai/"
+Homepage = "https://idea.idsia.ch/ant-ai/"
+Documentation = "https://idea.idsia.ch/ant-ai/"
 Repository = "https://github.com/idea-idsia/ant-ai"
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Update `Homepage` and `Documentation` URLs in `pyproject.toml` from `https://idea-idsia.github.io/ant-ai/` to `https://idea.idsia.ch/ant-ai/`