### PR TITLE
fix(ci): checkout main explicitly to prevent non-fast-forward push on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  ref: main
                   token: ${{ secrets.RELEASE_PAT }}
 
             - uses: astral-sh/setup-uv@v8.2.0


### PR DESCRIPTION
## Summary
- Adds `ref: main` to the checkout step in `release.yml` so the workflow always starts from the latest `main` instead of the PR branch head
- Without this, the push back to `main` was rejected as non-fast-forward because the merge commit on `main` was ahead of the checked-out PR branch

## Root cause
When a `pull_request` event triggers the workflow, `actions/checkout` defaults to the PR branch HEAD, not the merged `main`. The version bump commit then has no knowledge of the merge commit, causing the push to fail.

## Test plan
- [ ] Merge this PR, then trigger the release workflow via `workflow_dispatch` with `minor` bump to publish v1.5.0