### PR TITLE
fix(hooks): prevent orphaned tool messages and keep_last=0 no-op in HistoryCompressionHook

### DIFF
--- a/src/ant_ai/hooks/builtins/history_compression.py
+++ b/src/ant_ai/hooks/builtins/history_compression.py
@@ -99,8 +99,24 @@ class HistoryCompressionHook(AgentHook, BaseModel):
         if len(messages) <= self.keep_last or not self._should_compress(messages):
             return
 
-        to_compress: list[Message] = messages[: -self.keep_last]
-        keep: list[Message] = messages[-self.keep_last :]
+        # messages[:-0] is [] in Python, so handle keep_last=0 ("compress all") explicitly.
+        keep_from: int = (
+            len(messages) - self.keep_last if self.keep_last > 0 else len(messages)
+        )
+
+        # Never orphan a ToolCallResultMessage: a `tool` role message must always be
+        # preceded by an assistant message with tool_calls. Slide the boundary left
+        # until it no longer points inside a tool-call/result group.
+        while 0 < keep_from < len(messages) and messages[keep_from].role == "tool":
+            keep_from -= 1
+
+        to_compress: list[Message] = messages[:keep_from]
+        keep: list[Message] = messages[keep_from:]
+
+        # Nothing compressible after boundary adjustment (e.g. history starts with a
+        # tool-call group that would be broken by any split).
+        if not to_compress:
+            return
 
         history_text: str = "\n".join(
             f"{m.role}: {m.content or ''}" for m in to_compress

--- a/tests/unit/hooks/test_history_compression.py
+++ b/tests/unit/hooks/test_history_compression.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from ant_ai.core.message import Message
+from ant_ai.core.message import (
+    Message,
+    ToolCall,
+    ToolCallMessage,
+    ToolCallResultMessage,
+    ToolFunction,
+)
 from ant_ai.core.types import State
 from ant_ai.hooks.builtins.history_compression import (
     _SUMMARY_PREFIX,
@@ -237,3 +243,195 @@ async def test_compression_context_excludes_current_user_message():
     assert "user_N" not in contents
     assert "keep2" in contents
     assert "keep3" in contents
+
+
+# ---------------------------------------------------------------------------
+# Tool-call sequence integrity
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_group(
+    call_id: str = "call_1",
+) -> tuple[ToolCallMessage, ToolCallResultMessage]:
+    """Return a matched (ToolCallMessage, ToolCallResultMessage) pair."""
+    call = ToolCallMessage(
+        tool_calls=[
+            ToolCall(id=call_id, function=ToolFunction(name="mytool", arguments="{}"))
+        ]
+    )
+    result = ToolCallResultMessage(
+        tool_call_id=call_id, name="mytool", content="result"
+    )
+    return call, result
+
+
+def _assert_valid_tool_sequence(messages: list[Message]) -> None:
+    """Assert no orphaned tool-result messages exist in the sequence."""
+    for i, msg in enumerate(messages):
+        if msg.role == "tool":
+            assert i > 0, f"tool message at index {i} has no preceding message"
+            prev = messages[i - 1]
+            assert prev.role in ("assistant", "tool"), (
+                f"tool message at index {i} is orphaned: preceded by role='{prev.role}'"
+            )
+
+
+@pytest.mark.unit
+async def test_orphaned_tool_result_at_boundary_is_fixed():
+    """Boundary that would orphan a ToolCallResultMessage is slid left to include its ToolCallMessage."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=3)
+
+    # [user1, tool_call, tool_result, user2, user3]
+    # Initial split at index 2 → keep starts with tool_result (role="tool") → orphan!
+    # Fix: boundary moves left to index 1 → keep = [tool_call, tool_result, user2, user3]
+    call, result = _make_tool_group()
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(call)
+    state.add_message(result)
+    state.add_message(Message(role="user", content="user2"))
+    state.add_message(Message(role="user", content="user3"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls, "LLM should have been called"
+    _assert_valid_tool_sequence(state.messages)
+
+
+@pytest.mark.unit
+async def test_multiple_tool_results_kept_intact():
+    """When multiple tool results follow one call, all are slid into keep together."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=3)
+
+    # [user1, tool_call, result1, result2, user2]
+    # Initial split at 2 → keep = [result1, result2, user2] → orphaned
+    # Fix: boundary slides to 1 → keep = [tool_call, result1, result2, user2]
+    call = ToolCallMessage(
+        tool_calls=[ToolCall(id="c1", function=ToolFunction(name="t", arguments="{}"))]
+    )
+    result1 = ToolCallResultMessage(tool_call_id="c1", name="t", content="r1")
+    result2 = ToolCallResultMessage(tool_call_id="c1", name="t", content="r2")
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(call)
+    state.add_message(result1)
+    state.add_message(result2)
+    state.add_message(Message(role="user", content="user2"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    # tool_call + both results all land in keep
+    roles = [m.role for m in state.messages]
+    tool_idx = roles.index("assistant") if "assistant" in roles else -1
+    assert tool_idx != -1
+    assert roles[tool_idx + 1] == "tool"
+    assert roles[tool_idx + 2] == "tool"
+
+
+@pytest.mark.unit
+async def test_tool_group_fully_in_to_compress_is_unaffected():
+    """A tool-call group that falls entirely in to_compress requires no boundary adjustment."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=2)
+
+    # [user1, tool_call, tool_result, user2, user3]
+    # Initial split at 3 → to_compress = [user1, tool_call, tool_result], keep = [user2, user3]
+    # keep[0].role = "user" → no adjustment needed
+    call, result = _make_tool_group()
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(call)
+    state.add_message(result)
+    state.add_message(Message(role="user", content="user2"))
+    state.add_message(Message(role="user", content="user3"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    # keep_last=2 preserved: last two user messages
+    kept_contents = [m.content for m in state.messages[-2:]]
+    assert kept_contents == ["user2", "user3"]
+
+
+@pytest.mark.unit
+async def test_no_compression_when_boundary_adjustment_empties_to_compress():
+    """If boundary adjustment leaves nothing to compress, the hook is a no-op."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=4)
+
+    # [tool_call, result, user1, user2, user3]
+    # Initial split at 1 → messages[1].role = "tool" → slide to 0
+    # to_compress = [] → no-op
+    call, result = _make_tool_group()
+    state = State()
+    state.add_message(call)
+    state.add_message(result)
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(Message(role="user", content="user2"))
+    state.add_message(Message(role="user", content="user3"))
+
+    original = list(state.messages)
+    await hook.before_model(state, ctx=None)
+
+    assert not llm.calls, "LLM should not be called when nothing is left to compress"
+    assert state.messages == original
+
+
+# ---------------------------------------------------------------------------
+# keep_last=0 — compress everything
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_keep_last_zero_compresses_all_messages():
+    """keep_last=0 should compress the entire history into a single summary message."""
+    llm = _CapturingLLM("full history summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=3, keep_last=0)
+
+    state = _state("m1", "m2", "m3")
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls, "LLM should have been called"
+    assert len(state.messages) == 1
+    assert state.messages[0].role == "system"
+    assert state.messages[0].content == f"{_SUMMARY_PREFIX}full history summary"
+
+
+@pytest.mark.unit
+async def test_keep_last_zero_sends_full_history_to_summariser():
+    """With keep_last=0 all messages are sent to the summariser, not just a subset."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=3, keep_last=0)
+
+    state = _state("alpha", "beta", "gamma")
+    await hook.before_model(state, ctx=None)
+
+    prompt_content = llm.calls[0][0].content
+    assert "alpha" in prompt_content
+    assert "beta" in prompt_content
+    assert "gamma" in prompt_content
+
+
+@pytest.mark.unit
+async def test_keep_last_zero_no_orphaned_tool_messages():
+    """With keep_last=0, tool-call groups are fully included in to_compress — no orphans."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=3, keep_last=0)
+
+    call, result = _make_tool_group()
+    state = State()
+    state.add_message(Message(role="user", content="q"))
+    state.add_message(call)
+    state.add_message(result)
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    # Everything compressed → only summary remains; no tool messages to orphan
+    assert len(state.messages) == 1
+    assert state.messages[0].role == "system"


### PR DESCRIPTION
## Summary

- **Bug 1 — `keep_last=0` no-op:** `messages[:-0]` evaluates to `[]` in Python, so `to_compress` was always empty when `keep_last=0`. Instead of compressing the history, a junk summary (produced from an empty prompt) was prepended on every invocation, making the history grow unboundedly. This is what produced the stacked `[Conversation summary] Sure—please paste...` messages visible in the trace.
- **Bug 2 — orphaned `ToolCallResultMessage`:** The split at the `keep_last` boundary could place a `tool`-role message at the head of the preserved slice with no preceding `ToolCallMessage`, causing OpenAI to reject the request with a 400 `"messages with role 'tool' must be a response to a preceding message with 'tool_calls'"` error (#76).

## Changes

- `src/ant_ai/hooks/builtins/history_compression.py`: replace `messages[:-keep_last]` slice with explicit index arithmetic; slide the boundary left while it points inside a tool-call/result group; guard against an empty `to_compress` after adjustment.
- `tests/unit/hooks/test_history_compression.py`: 7 new unit tests covering both bugs and edge cases (multiple tool results, group fully in `to_compress`, no-op after adjustment, `keep_last=0` full compression).

## Test plan

- [x] All 23 unit tests pass (`pytest tests/unit/hooks/test_history_compression.py`)
- [x] New tests cover: `keep_last=0` compresses all messages, `keep_last=0` sends full history to summariser, orphaned single result fixed, orphaned multiple results fixed, tool group fully in `to_compress` unaffected, no-op when adjustment empties `to_compress`, `keep_last=0` with tool messages

Closes #76