### PR TITLE
fix(hooks): guard against orphaned ToolCallMessage and incomplete parallel tool results

### DIFF
--- a/src/ant_ai/hooks/builtins/history_compression.py
+++ b/src/ant_ai/hooks/builtins/history_compression.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar, Self
 
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation, model_validator
 
-from ant_ai.core.message import Message
+from ant_ai.core.message import Message, ToolCallMessage
 from ant_ai.core.types import InvocationContext, State
 from ant_ai.hooks.protocol import AgentHook
 
@@ -104,11 +104,29 @@ class HistoryCompressionHook(AgentHook, BaseModel):
             len(messages) - self.keep_last if self.keep_last > 0 else len(messages)
         )
 
-        # Never orphan a ToolCallResultMessage: a `tool` role message must always be
-        # preceded by an assistant message with tool_calls. Slide the boundary left
-        # until it no longer points inside a tool-call/result group.
+        # Slide left: never orphan a ToolCallResultMessage at the head of `keep`.
+        # A `tool` role message must always be preceded by an assistant message with
+        # tool_calls; slide left until the boundary no longer bisects such a group.
         while 0 < keep_from < len(messages) and messages[keep_from].role == "tool":
             keep_from -= 1
+
+        # Slide right: if the boundary lands on a ToolCallMessage whose results are
+        # absent or incomplete (e.g. broken A2A history or partial parallel calls),
+        # absorb the whole group into `to_compress` so it is summarised away instead
+        # of producing an invalid call.  For parallel tool calls, ALL N results must
+        # immediately follow — so compare the consecutive result count against the
+        # number of tool_calls in the message.
+        while keep_from < len(messages) and isinstance(
+            messages[keep_from], ToolCallMessage
+        ):
+            n_calls = len(messages[keep_from].tool_calls)
+            j = keep_from + 1
+            while j < len(messages) and messages[j].role == "tool":
+                j += 1
+            n_results = j - (keep_from + 1)
+            if n_results >= n_calls:
+                break  # Enough results follow — valid group, keep it.
+            keep_from = j  # Partial or absent results → absorb group into to_compress.
 
         to_compress: list[Message] = messages[:keep_from]
         keep: list[Message] = messages[keep_from:]

--- a/tests/unit/hooks/test_history_compression.py
+++ b/tests/unit/hooks/test_history_compression.py
@@ -266,13 +266,18 @@ def _make_tool_group(
 
 
 def _assert_valid_tool_sequence(messages: list[Message]) -> None:
-    """Assert no orphaned tool-result messages exist in the sequence."""
+    """Assert the sequence contains no broken tool-call pairs in either direction."""
     for i, msg in enumerate(messages):
         if msg.role == "tool":
             assert i > 0, f"tool message at index {i} has no preceding message"
             prev = messages[i - 1]
             assert prev.role in ("assistant", "tool"), (
                 f"tool message at index {i} is orphaned: preceded by role='{prev.role}'"
+            )
+        if isinstance(msg, ToolCallMessage):
+            has_result = i + 1 < len(messages) and messages[i + 1].role == "tool"
+            assert has_result, (
+                f"ToolCallMessage at index {i} has no immediately following tool result"
             )
 
 
@@ -382,11 +387,6 @@ async def test_no_compression_when_boundary_adjustment_empties_to_compress():
     assert state.messages == original
 
 
-# ---------------------------------------------------------------------------
-# keep_last=0 — compress everything
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 async def test_keep_last_zero_compresses_all_messages():
     """keep_last=0 should compress the entire history into a single summary message."""
@@ -435,3 +435,177 @@ async def test_keep_last_zero_no_orphaned_tool_messages():
     # Everything compressed → only summary remains; no tool messages to orphan
     assert len(state.messages) == 1
     assert state.messages[0].role == "system"
+
+
+@pytest.mark.unit
+async def test_orphaned_tool_call_at_boundary_slides_into_to_compress():
+    """If keep would start with a ToolCallMessage not followed by a result, slide it right into to_compress."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=3)
+
+    # [user1, ToolCallMessage(call_X), user2, user3]  — no tool result (invalid history)
+    # keep_last=3 → keep_from=1 → messages[1]=ToolCallMessage, messages[2]=user (not tool)
+    # RIGHT slide: keep_from → 2
+    # to_compress=[user1, ToolCallMessage], keep=[user2, user3]
+    call = ToolCallMessage(
+        tool_calls=[
+            ToolCall(id="call_X", function=ToolFunction(name="t", arguments="{}"))
+        ]
+    )
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(call)
+    state.add_message(Message(role="user", content="user2"))
+    state.add_message(Message(role="user", content="user3"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    assert all(not isinstance(m, ToolCallMessage) for m in state.messages)
+
+
+@pytest.mark.unit
+async def test_orphaned_tool_call_as_last_message_slides_into_to_compress():
+    """A ToolCallMessage at the very end of keep (no following message) is moved to to_compress."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=1)
+
+    # [user1, user2, user3, ToolCallMessage(call_X)]  — tool call is last message, no result
+    # keep_last=1 → keep_from=3 → messages[3]=ToolCallMessage, nothing follows
+    # RIGHT slide: keep_from → 4 = len(messages)
+    # to_compress = all, keep = []
+    call = ToolCallMessage(
+        tool_calls=[
+            ToolCall(id="call_X", function=ToolFunction(name="t", arguments="{}"))
+        ]
+    )
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(Message(role="user", content="user2"))
+    state.add_message(Message(role="user", content="user3"))
+    state.add_message(call)
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    assert len(state.messages) == 1
+    assert state.messages[0].role == "system"
+
+
+@pytest.mark.unit
+async def test_valid_tool_call_at_boundary_not_disturbed():
+    """A ToolCallMessage at the start of keep that IS followed by its result is left alone."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=3)
+
+    # [user1, ToolCallMessage(call_X), ToolCallResult(call_X), user2]
+    # keep_last=3 → keep_from=1 → messages[1]=ToolCallMessage, messages[2]=tool result
+    # RIGHT slide: next is tool → stop (valid pair)
+    # keep=[ToolCallMessage, ToolCallResult, user2]
+    call, result = _make_tool_group()
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(call)
+    state.add_message(result)
+    state.add_message(Message(role="user", content="user2"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    # ToolCallMessage and its result must both be in keep
+    assert any(isinstance(m, ToolCallMessage) for m in state.messages)
+    assert any(m.role == "tool" for m in state.messages)
+
+
+def _make_parallel_tool_group(
+    n: int,
+) -> tuple[ToolCallMessage, list[ToolCallResultMessage]]:
+    """Return (ToolCallMessage with n calls, [n ToolCallResultMessages])."""
+    calls = [
+        ToolCall(id=f"call_{i}", function=ToolFunction(name="t", arguments="{}"))
+        for i in range(n)
+    ]
+    tcm = ToolCallMessage(tool_calls=calls)
+    results = [
+        ToolCallResultMessage(tool_call_id=f"call_{i}", name="t", content="ok")
+        for i in range(n)
+    ]
+    return tcm, results
+
+
+@pytest.mark.unit
+async def test_parallel_tool_calls_all_results_kept_intact():
+    """ToolCallMessage with N calls followed by N results: entire group stays in keep."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=4)
+
+    # [user1, ToolCallMessage([A,B]), ToolResult(A), ToolResult(B), user2]
+    # keep_last=4 → keep_from=1 → ToolCallMessage has 2 results → break, no slide
+    tcm, results = _make_parallel_tool_group(2)
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(tcm)
+    for r in results:
+        state.add_message(r)
+    state.add_message(Message(role="user", content="user2"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    assert any(isinstance(m, ToolCallMessage) for m in state.messages)
+    assert sum(1 for m in state.messages if m.role == "tool") == 2
+
+
+@pytest.mark.unit
+async def test_parallel_tool_calls_partial_results_slides_into_to_compress():
+    """ToolCallMessage with 2 calls but only 1 result: whole group absorbed into to_compress."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=3)
+
+    # [user1, ToolCallMessage([A,B]), ToolResult(A), user2]  — missing ToolResult(B)
+    # keep_last=3 → keep_from=1 → ToolCallMessage has 2 calls but only 1 result
+    # RIGHT slide: n_calls=2, n_results=1 → absorb: keep_from=3
+    tcm, results = _make_parallel_tool_group(2)
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(tcm)
+    state.add_message(results[0])  # only first result; second is missing
+    state.add_message(Message(role="user", content="user2"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    # ToolCallMessage and the partial result both absorbed into summary
+    assert not any(isinstance(m, ToolCallMessage) for m in state.messages)
+    assert not any(m.role == "tool" for m in state.messages)
+
+
+@pytest.mark.unit
+async def test_parallel_tool_calls_left_slide_keeps_full_group():
+    """If the boundary bisects a parallel group's results, left-slide pulls the whole group into keep."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=2)
+
+    # [user1, ToolCallMessage([A,B]), ToolResult(A), ToolResult(B), user2]
+    # keep_last=2 → keep_from=3 → messages[3]=ToolResult(B) (role=tool)
+    # LEFT slide: 3→2 (ToolResult A, still tool), 2→1 (ToolCallMessage, not tool) → stop
+    # RIGHT slide: messages[1] is ToolCallMessage, n_calls=2, n_results=2 → break
+    # keep=[ToolCallMessage, ToolResult(A), ToolResult(B), user2]
+    tcm, results = _make_parallel_tool_group(2)
+    state = State()
+    state.add_message(Message(role="user", content="user1"))
+    state.add_message(tcm)
+    for r in results:
+        state.add_message(r)
+    state.add_message(Message(role="user", content="user2"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    _assert_valid_tool_sequence(state.messages)
+    assert any(isinstance(m, ToolCallMessage) for m in state.messages)
+    assert sum(1 for m in state.messages if m.role == "tool") == 2


### PR DESCRIPTION
## Problem

After `HistoryCompressionHook` slides the compression boundary, two additional invalid message sequences could survive into `keep`:

1. **Absent results** — `keep` starts with a `ToolCallMessage` that has *no* tool result immediately following it (e.g. incomplete history reconstructed from A2A tasks where a task failed between `ToolCallingEvent` and `ToolResultEvent`).
2. **Partial parallel results** — `keep` starts with a `ToolCallMessage` that issued N parallel tool calls but only M < N `ToolCallResultMessage`s follow.

Both produce an OpenAI 400 Bad Request:
> `"An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'"`

## Fix

After the existing left-slide (which prevents orphaned `ToolCallResultMessage`s), add a **right-slide** in `HistoryCompressionHook.before_model`:

- Count the consecutive `tool`-role messages immediately following the `ToolCallMessage`
- Compare against `len(tool_calls)` in that message
- If the count is short (absent or partial), move `keep_from` right past the entire group so it is absorbed into `to_compress` and summarised away