### PR TITLE
fix(hooks): surface guardrails validation failure details in PostModelRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ The `guardrails-ai` extra installs the core library. Validators (e.g. `ToxicLang
 ```sh
 # Run from outside the project directory so uv doesn't pick up exclude-newer
 (cd /tmp && guardrails hub install hub://guardrails/toxic_language hub://guardrails/detect_pii)
+# Copy the registry into the project root so imports resolve from here
+cp /tmp/.guardrails/hub_registry.json .guardrails/
 ```
 
 > **Note:** hub validators are installed outside of uv's lockfile and must be reinstalled after `uv sync`.
 > The `cd /tmp` wrapper is required because these packages ship without upload dates, which conflicts with the project's `exclude-newer = "P2D"` supply-chain setting. Running from `/tmp` (where no `pyproject.toml` exists) lets uv install them without that constraint while still targeting the active virtualenv.
+> The `hub_registry.json` copy is needed because guardrails resolves hub imports from a `.guardrails/hub_registry.json` file relative to the current working directory.
 
 Or clone and sync for local development:
 

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -4,7 +4,7 @@ import asyncio
 import threading
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict, PrivateAttr, SkipValidation
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, SkipValidation
 
 from ant_ai.core.result import LLMOutput, StepResult
 from ant_ai.core.types import InvocationContext
@@ -22,6 +22,17 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
     Only overrides ``after_model`` — validates the LLM output text and
     returns ``PostModelRetry`` if validation fails.
+
+    Args:
+        guard: A configured ``guardrails.Guard`` instance.
+        num_reasks: How many times guardrails may internally call an LLM to
+            fix invalid output before handing control back to ant-ai.  The
+            default (``0``) disables guardrails' own reask loop so ant-ai's
+            retry mechanism stays in control.  Set to a positive value only
+            when the guard has an ``llm_api`` configured and you want
+            guardrails to attempt self-correction before ant-ai retries.
+        api_key: API key forwarded to the LLM used by guardrails during
+            internal reasks.  Only relevant when ``num_reasks > 0``.
 
     .. note::
         ``Guard`` is not thread-safe. Validation calls on a shared hook
@@ -47,6 +58,8 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
     name: ClassVar[str] = "guardrails_ai"
     guard: SkipValidation[Any]  # guardrails.Guard
+    num_reasks: int = Field(default=0, ge=0)
+    api_key: str | None = None
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     async def after_model(
@@ -64,7 +77,10 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
         def _validate() -> Any:
             with self._lock:
-                return self.guard.validate(raw)
+                kwargs: dict[str, Any] = {}
+                if self.api_key is not None:
+                    kwargs["api_key"] = self.api_key
+                return self.guard.validate(raw, num_reasks=self.num_reasks, **kwargs)
 
         outcome = await asyncio.to_thread(_validate)
 

--- a/tests/integration/hooks/test_guardrails_ai_integration.py
+++ b/tests/integration/hooks/test_guardrails_ai_integration.py
@@ -8,15 +8,16 @@ pytest.importorskip(
 )
 
 from guardrails import Guard
+from guardrails.classes import FailResult
+from guardrails.types import OnFailAction
+from guardrails.validator_base import Validator, register_validator
 
 try:
     from guardrails.hub import DetectPII
+
+    _DETECT_PII_AVAILABLE = True
 except ImportError:
-    pytest.skip(
-        "guardrails hub validators not installed; run from outside the project: "
-        "(cd /tmp && guardrails hub install hub://guardrails/detect_pii hub://guardrails/toxic_language)",
-        allow_module_level=True,
-    )
+    _DETECT_PII_AVAILABLE = False
 
 try:
     from guardrails.hub import ToxicLanguage
@@ -28,9 +29,68 @@ except ImportError:
 from ant_ai.agent.agent import Agent
 from ant_ai.core.exceptions import HookMaxRetriesError
 from ant_ai.core.message import Message
+from ant_ai.core.result import LLMOutput, StepResult, Transition, TransitionAction
 from ant_ai.core.types import State
 from ant_ai.hooks.integrations import GuardrailsAIHook
+from ant_ai.hooks.protocol import PostModelRetry
 from ant_ai.llm.integrations.lite_llm import LiteLLMChat
+
+
+def _llm_result(raw: str) -> StepResult:
+    return StepResult(
+        output=LLMOutput(raw=raw),
+        transition=Transition(action=TransitionAction.END),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.guardrailsai
+async def test_failure_reason_is_present_in_retry():
+    """Real Guard + real validator — no mocks, no external LLM.
+
+    Verifies that PostModelRetry.reason contains the validator name and the
+    specific error message returned by the validator, in the expected
+    ``"validator_name: error_message"`` format.
+    """
+
+    @register_validator(name="always_fails", data_type="string")
+    class AlwaysFails(Validator):
+        def validate(self, value, metadata):
+            return FailResult(error_message="forbidden content detected")
+
+    guard = Guard().use(AlwaysFails(on_fail=OnFailAction.NOOP))
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(_llm_result("any text"), ctx=None)
+
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason == "AlwaysFails: forbidden content detected"
+
+
+@pytest.mark.integration
+@pytest.mark.guardrailsai
+async def test_failure_reason_multiple_validators():
+    """Two real validators — reason must join both with ``'; '``."""
+
+    @register_validator(name="check_a", data_type="string")
+    class CheckA(Validator):
+        def validate(self, value, metadata):
+            return FailResult(error_message="issue A")
+
+    @register_validator(name="check_b", data_type="string")
+    class CheckB(Validator):
+        def validate(self, value, metadata):
+            return FailResult(error_message="issue B")
+
+    guard = Guard().use(
+        CheckA(on_fail=OnFailAction.NOOP), CheckB(on_fail=OnFailAction.NOOP)
+    )
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(_llm_result("any text"), ctx=None)
+
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason == "CheckA: issue A; CheckB: issue B"
 
 
 def _state(content: str) -> State:
@@ -55,7 +115,7 @@ def _safe_agent(guard: Guard) -> Agent:
 @pytest.mark.guardrailsai
 @pytest.mark.skipif(
     not _TOXIC_LANGUAGE_AVAILABLE,
-    reason="ToxicLanguage hub validator not importable (detoxify/transformers conflict)",
+    reason="ToxicLanguage hub validator not installed",
 )
 async def test_toxic_language_validator_self_corrects():
     # on_fail="reask" returns a failing ValidationOutcome without internal LLM
@@ -70,11 +130,15 @@ async def test_toxic_language_validator_self_corrects():
 
 @pytest.mark.external
 @pytest.mark.guardrailsai
+@pytest.mark.skipif(
+    not _DETECT_PII_AVAILABLE,
+    reason="DetectPII hub validator not installed",
+)
 async def test_pii_validator_triggers_retry_or_raises():
     guard = Guard().use(
         # on_fail="reask": guardrails returns a failing outcome (no internal LLM
         # reask since validate() has no llm_api); ant-ai's retry loop takes over.
-        DetectPII(pii_entities=["EMAIL_ADDRESS", "PHONE_NUMBER"], on_fail="reask")
+        DetectPII(pii_entities=["EMAIL_ADDRESS", "PHONE_NUMBER"], on_fail="reask")  # type: ignore[name-defined]
     )
     agent = _safe_agent(guard)
     try:

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -66,13 +66,36 @@ async def test_pass_when_validation_succeeds():
 
 @pytest.mark.unit
 @pytest.mark.guardrailsai
-async def test_retry_when_validation_fails():
+async def test_retry_reason_format():
     hook = GuardrailsAIHook(
         guard=_make_guard(passed=False, failure_reason="toxic content detected")
     )
     decision = await hook.after_model(_llm_result("bad output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
-    assert "toxic content detected" in decision.reason
+    assert decision.reason == "test: toxic content detected"
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_retry_reason_multiple_validators():
+    summaries = [
+        _MockSummary(
+            validator_name="detect_pii", failure_reason="EMAIL_ADDRESS detected"
+        ),
+        _MockSummary(
+            validator_name="toxic_language", failure_reason="toxicity score 0.92"
+        ),
+    ]
+    outcome = _MockOutcome(validation_passed=False, validation_summaries=summaries)
+    guard = MagicMock()
+    guard.validate.return_value = outcome
+    hook = GuardrailsAIHook(guard=guard)
+    decision = await hook.after_model(_llm_result("bad output"), ctx=None)
+    assert isinstance(decision, PostModelRetry)
+    assert (
+        decision.reason
+        == "detect_pii: EMAIL_ADDRESS detected; toxic_language: toxicity score 0.92"
+    )
 
 
 @pytest.mark.unit
@@ -82,6 +105,45 @@ async def test_retry_reason_falls_back_when_no_summaries():
     decision = await hook.after_model(_llm_result("bad output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
     assert decision.reason == "validation failed"
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_validate_called_with_num_reasks_zero():
+    guard = _make_guard(passed=True)
+    hook = GuardrailsAIHook(guard=guard)
+    await hook.after_model(_llm_result("clean output"), ctx=None)
+    guard.validate.assert_called_once_with("clean output", num_reasks=0)
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_validate_called_with_custom_num_reasks():
+    guard = _make_guard(passed=True)
+    hook = GuardrailsAIHook(guard=guard, num_reasks=2)
+    await hook.after_model(_llm_result("clean output"), ctx=None)
+    guard.validate.assert_called_once_with("clean output", num_reasks=2)
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_validate_forwards_api_key():
+    guard = _make_guard(passed=True)
+    hook = GuardrailsAIHook(guard=guard, api_key="sk-test")
+    await hook.after_model(_llm_result("clean output"), ctx=None)
+    guard.validate.assert_called_once_with(
+        "clean output", num_reasks=0, api_key="sk-test"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_validate_no_api_key_kwarg_when_none():
+    guard = _make_guard(passed=True)
+    hook = GuardrailsAIHook(guard=guard)
+    await hook.after_model(_llm_result("clean output"), ctx=None)
+    _, kwargs = guard.validate.call_args
+    assert "api_key" not in kwargs
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Pass `num_reasks=0` to `guard.validate()` to prevent guardrails from firing an internal LLM-reask loop. Without this, the default `num_reasks=1` starts a second validation iteration (no `llm_api` provided), which produces empty `validator_logs`; `from_guard_history` reads `iterations.last` (the empty second pass) and finds no summaries, so `_failure_reason()` always falls back to `"validation failed"` — the LLM retry receives no actionable feedback.
- Expose `num_reasks: int = 0` and `api_key: str | None = None` as constructor fields on `GuardrailsAIHook` so users can opt into guardrails-driven reasks when they have an `llm_api` configured on the guard.
- Add unit tests pinning the exact `"validator_name: error_message"` reason format and the `"; "`-joined multi-validator form.
- Add integration tests using real `Guard` + custom validators (no mocks, no external LLM) that assert the actual reason string surfaced to the retry prompt.
- Restructure the integration test module so hub-validator imports no longer block tests that only need guardrails core.


Closes #78