### PR TITLE
fix(hooks): treat validation_summaries as authoritative over validation_passed

### DIFF
--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -73,7 +73,7 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         # Guard.validate is synchronous and mutates internal state (history,
         # reask counter). Serialize via _lock so concurrent callers sharing
         # this hook instance do not race on that state.
-        raw = result.output.raw
+        raw: str = result.output.raw
 
         def _validate() -> Any:
             with self._lock:
@@ -84,10 +84,15 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
         outcome = await asyncio.to_thread(_validate)
 
-        if outcome.validation_passed:
+        reason: str = _failure_reason(outcome.validation_summaries)
+
+        if outcome.validation_passed and reason == _FALLBACK_REASON:
             return PostModelPass(result=result)
 
-        return PostModelRetry(reason=_failure_reason(outcome.validation_summaries))
+        return PostModelRetry(reason=reason)
+
+
+_FALLBACK_REASON = "validation failed"
 
 
 def _failure_reason(summaries: list | None) -> str:
@@ -96,9 +101,9 @@ def _failure_reason(summaries: list | None) -> str:
     outcome.error is only populated when validate() raises an exception;
     for normal FailResult failures the details live in validation_summaries.
     """
-    parts = [
+    parts: list[str] = [
         f"{s.validator_name}: {s.failure_reason}"
         for s in (summaries or [])
         if s.failure_reason
     ]
-    return "; ".join(parts) if parts else "validation failed"
+    return "; ".join(parts) if parts else _FALLBACK_REASON

--- a/tests/integration/hooks/test_guardrails_ai_integration.py
+++ b/tests/integration/hooks/test_guardrails_ai_integration.py
@@ -93,6 +93,91 @@ async def test_failure_reason_multiple_validators():
     assert decision.reason == "CheckA: issue A; CheckB: issue B"
 
 
+@pytest.mark.integration
+@pytest.mark.guardrailsai
+async def test_failure_reason_present_with_on_fail_noop():
+    """on_fail='noop' — validation_passed is correctly False and summaries are
+    populated; the hook must surface the reason."""
+
+    @register_validator(name="always_fails_noop", data_type="string")
+    class AlwaysFailsNoop(Validator):
+        def validate(self, value, metadata):
+            return FailResult(error_message="noop failure reason")
+
+    guard = Guard().use(AlwaysFailsNoop(on_fail=OnFailAction.NOOP))
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(_llm_result("any text"), ctx=None)
+
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason == "AlwaysFailsNoop: noop failure reason"
+
+
+@pytest.mark.integration
+@pytest.mark.guardrailsai
+async def test_failure_reason_present_with_on_fail_reask():
+    """on_fail='reask' causes guardrails to set validation_passed=True when
+    num_reasks=0 (unresolved FieldReAsk is not propagated through fixed_output).
+    The hook must fall back to validation_summaries as the authoritative signal."""
+
+    @register_validator(name="always_fails_reask", data_type="string")
+    class AlwaysFailsReask(Validator):
+        def validate(self, value, metadata):
+            return FailResult(error_message="reask failure reason")
+
+    guard = Guard().use(AlwaysFailsReask(on_fail=OnFailAction.REASK))
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(_llm_result("any text"), ctx=None)
+
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason == "AlwaysFailsReask: reask failure reason"
+
+
+@pytest.mark.integration
+@pytest.mark.guardrailsai
+@pytest.mark.skipif(
+    not _DETECT_PII_AVAILABLE, reason="DetectPII hub validator not installed"
+)
+async def test_detect_pii_reason_noop():
+    """Real DetectPII validator with on_fail='noop' — reason must start with
+    'DetectPII:' and come from the actual validator, not a fallback string."""
+    guard = Guard().use(
+        DetectPII(pii_entities=["EMAIL_ADDRESS"], on_fail="noop")  # type: ignore[name-defined]
+    )
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(
+        _llm_result("Contact me at john@example.com"), ctx=None
+    )
+
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason.startswith("DetectPII:")
+    assert decision.reason != "validation failed"
+
+
+@pytest.mark.integration
+@pytest.mark.guardrailsai
+@pytest.mark.skipif(
+    not _DETECT_PII_AVAILABLE, reason="DetectPII hub validator not installed"
+)
+async def test_detect_pii_reason_reask():
+    """Real DetectPII validator with on_fail='reask' — guardrails incorrectly sets
+    validation_passed=True when num_reasks=0; the hook must still surface the reason."""
+    guard = Guard().use(
+        DetectPII(pii_entities=["EMAIL_ADDRESS"], on_fail="reask")  # type: ignore[name-defined]
+    )
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(
+        _llm_result("Contact me at john@example.com"), ctx=None
+    )
+
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason.startswith("DetectPII:")
+    assert decision.reason != "validation failed"
+
+
 def _state(content: str) -> State:
     s = State()
     s.add_message(Message(role="user", content=content))
@@ -118,10 +203,10 @@ def _safe_agent(guard: Guard) -> Agent:
     reason="ToxicLanguage hub validator not installed",
 )
 async def test_toxic_language_validator_self_corrects():
-    # on_fail="reask" returns a failing ValidationOutcome without internal LLM
-    # calls (no llm_api passed to validate()). ant-ai's retry loop takes over.
+    # on_fail="noop": guardrails reports the failure without attempting self-correction.
+    # ant-ai's retry loop owns correction via PostModelRetry.
     guard = Guard().use(
-        ToxicLanguage(threshold=0.5, validation_method="sentence", on_fail="reask")  # type: ignore[name-defined]
+        ToxicLanguage(threshold=0.5, validation_method="sentence", on_fail="noop")  # type: ignore[name-defined]
     )
     agent = _safe_agent(guard)
     answer = await agent.ainvoke(_state("Explain why collaboration matters in teams."))
@@ -136,9 +221,9 @@ async def test_toxic_language_validator_self_corrects():
 )
 async def test_pii_validator_triggers_retry_or_raises():
     guard = Guard().use(
-        # on_fail="reask": guardrails returns a failing outcome (no internal LLM
-        # reask since validate() has no llm_api); ant-ai's retry loop takes over.
-        DetectPII(pii_entities=["EMAIL_ADDRESS", "PHONE_NUMBER"], on_fail="reask")  # type: ignore[name-defined]
+        # on_fail="noop": guardrails reports the failure and passes the output
+        # through unchanged — ant-ai's retry loop owns correction, not guardrails.
+        DetectPII(pii_entities=["EMAIL_ADDRESS", "PHONE_NUMBER"], on_fail="noop")  # type: ignore[name-defined]
     )
     agent = _safe_agent(guard)
     try:


### PR DESCRIPTION
## Summary

- With `on_fail="reask"` and `num_reasks=0`, guardrails incorrectly sets `validation_passed=True` because the unresolved `FieldReAsk` is never propagated through `fixed_output`. The `validation_summaries` are still correctly populated from the single validation pass, so the hook now uses them as the authoritative signal: if `_failure_reason()` produces an actual message (not the fallback `"validation failed"` string), `PostModelRetry` is returned regardless of `validation_passed`.
- Adds integration tests for both `on_fail="noop"` and `on_fail="reask"` using real `DetectPII`, asserting `decision.reason.startswith("DetectPII:")` — guaranteeing the real validator message reaches the LLM retry prompt, not a fabricated fallback.

## Test plan

- [x] `pytest -m "unit and guardrailsai"` — 9 unit tests pass
- [x] `pytest -m "integration and guardrailsai"` — 6 integration tests pass (real Guard + DetectPII, no LLM)
- [x] `pytest -m "external and guardrailsai"` — 2 external tests pass (real LLM)

Related to #78