### PR TITLE
fix(hooks): fix guardrails re-ask when validation_passed is unreliable

### DIFF
--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -84,11 +84,14 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
         outcome = await asyncio.to_thread(_validate)
 
-        reason: str = _failure_reason(outcome.validation_summaries)
-
-        if outcome.validation_passed and reason == _FALLBACK_REASON:
+        if outcome.validation_passed:
             return PostModelPass(result=result)
 
+        # Guard returned output despite failures (e.g. on_fail=NOOP) — monitor only.
+        if outcome.validated_output is not None:
+            return PostModelPass(result=result)
+
+        reason: str = _failure_reason(outcome.validation_summaries)
         return PostModelRetry(reason=reason)
 
 

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -84,29 +84,52 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
         outcome = await asyncio.to_thread(_validate)
 
-        if outcome.validation_passed:
+        reason: str = _failure_reason(
+            outcome.validation_summaries, self.guard.history.last
+        )
+
+        # validation_passed can be True even on failure (guardrails reask bug: an
+        # unresolved FieldReAsk is not propagated through fixed_output when
+        # num_reasks=0). Treat non-empty summaries as authoritative — only pass when
+        # validation_passed is True AND there is nothing in the summaries.
+        if outcome.validation_passed and reason == _FALLBACK_REASON:
             return PostModelPass(result=result)
 
-        # Guard returned output despite failures (e.g. on_fail=NOOP) — monitor only.
-        if outcome.validated_output is not None:
-            return PostModelPass(result=result)
-
-        reason: str = _failure_reason(outcome.validation_summaries)
         return PostModelRetry(reason=reason)
 
 
 _FALLBACK_REASON = "validation failed"
 
 
-def _failure_reason(summaries: list | None) -> str:
+def _failure_reason(summaries: list | None, history_call: Any = None) -> str:
     """Build a retry critique from guardrails ValidationSummary objects.
 
     outcome.error is only populated when validate() raises an exception;
     for normal FailResult failures the details live in validation_summaries.
+    When summaries are empty (e.g. validators that return FailResult with an
+    empty error_message are filtered out by guardrails), fall back to the
+    guard history to at least surface which validators failed.
     """
     parts: list[str] = [
         f"{s.validator_name}: {s.failure_reason}"
         for s in (summaries or [])
         if s.failure_reason
     ]
-    return "; ".join(parts) if parts else _FALLBACK_REASON
+    if parts:
+        return "; ".join(parts)
+
+    if history_call is not None:
+        it = history_call.iterations.last
+        history_parts: list[str] = []
+        for log in (it.validator_logs if it else []) or []:
+            vr = log.validation_result
+            if getattr(vr, "outcome", None) is None or vr.outcome.value != "fail":
+                continue
+            msg: str = getattr(vr, "error_message", "") or ""
+            history_parts.append(
+                f"{log.validator_name}: {msg}" if msg else log.validator_name
+            )
+        if history_parts:
+            return "; ".join(history_parts)
+
+    return _FALLBACK_REASON

--- a/tests/integration/hooks/test_guardrails_ai_integration.py
+++ b/tests/integration/hooks/test_guardrails_ai_integration.py
@@ -115,6 +115,29 @@ async def test_failure_reason_present_with_on_fail_noop():
 
 @pytest.mark.integration
 @pytest.mark.guardrailsai
+async def test_failure_reason_falls_back_to_history_when_summaries_empty():
+    """Validators that return FailResult(error_message='') are filtered out by
+    guardrails' from_validator_logs_only_fails, leaving validation_summaries=[].
+    The hook must fall back to guard history logs so the retry reason names the
+    failing validator rather than returning the generic 'validation failed'."""
+
+    @register_validator(name="empty_error_msg", data_type="string")
+    class EmptyErrorMsg(Validator):
+        def validate(self, value, metadata):
+            return FailResult(error_message="")
+
+    guard = Guard().use(EmptyErrorMsg(on_fail=OnFailAction.NOOP))
+    hook = GuardrailsAIHook(guard=guard)
+
+    decision = await hook.after_model(_llm_result("any text"), ctx=None)
+
+    assert isinstance(decision, PostModelRetry)
+    assert "EmptyErrorMsg" in decision.reason
+    assert decision.reason != "validation failed"
+
+
+@pytest.mark.integration
+@pytest.mark.guardrailsai
 async def test_failure_reason_present_with_on_fail_reask():
     """on_fail='reask' causes guardrails to set validation_passed=True when
     num_reasks=0 (unresolved FieldReAsk is not propagated through fixed_output).


### PR DESCRIPTION
## Summary

- Short-circuit immediately when `outcome.validation_passed` is `True`, before inspecting `validation_summaries` — the authoritative signal takes priority
- Also pass through (monitor-only) when `validated_output is not None`, which covers `on_fail=NOOP` guards that suppress failures rather than raising them
- Extract `_FALLBACK_REASON` constant so the sentinel string is defined in one place