### PR TITLE
Fix/guardrails validation summary

### DIFF
--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -71,21 +71,25 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         except Exception as exc:  # noqa: BLE001
             return PostModelRetry(reason=f"guardrails validation error: {exc}")
 
-        if outcome.validation_passed:
+        # When on_fail="reask" and num_reasks=0, guardrails quirk: it sets
+        # validation_passed=True even though validators failed (it expected to
+        # reask but couldn't). Detect real failures via validator_status.
+        failed = [
+            s for s in (outcome.validation_summaries or [])
+            if getattr(s, "validator_status", None) == "fail"
+        ]
+        if outcome.validation_passed and not failed:
             return PostModelPass(result=result)
 
         return PostModelRetry(reason=_failure_reason(outcome.validation_summaries))
 
 
 def _failure_reason(summaries: list | None) -> str:
-    """Build a retry critique from guardrails ValidationSummary objects.
-
-    outcome.error is only populated when validate() raises an exception;
-    for normal FailResult failures the details live in validation_summaries.
-    """
+    """Build a retry critique from guardrails ValidationSummary objects."""
     parts = [
         f"{s.validator_name}: {s.failure_reason}"
         for s in (summaries or [])
         if s.failure_reason
+        and getattr(s, "validator_status", "fail") == "fail"
     ]
     return "; ".join(parts) if parts else "validation failed"

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -104,7 +104,7 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         if outcome.validation_passed and not failed:
             return PostModelPass(result=result)
 
-        return PostModelRetry(reason=reason)
+        return PostModelRetry(reason=_failure_reason(outcome.validation_summaries))
 
 
 _FALLBACK_REASON = "validation failed"

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -98,7 +98,8 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         # validation_passed=True even though validators failed (it expected to
         # reask but couldn't). Detect real failures via validator_status.
         failed = [
-            s for s in (outcome.validation_summaries or [])
+            s
+            for s in (outcome.validation_summaries or [])
             if getattr(s, "validator_status", None) == "fail"
         ]
         if outcome.validation_passed and not failed:
@@ -122,8 +123,7 @@ def _failure_reason(summaries: list | None, history_call: Any = None) -> str:
     parts: list[str] = [
         f"{s.validator_name}: {s.failure_reason}"
         for s in (summaries or [])
-        if s.failure_reason
-        and getattr(s, "validator_status", "fail") == "fail"
+        if s.failure_reason and getattr(s, "validator_status", "fail") == "fail"
     ]
     if parts:
         return "; ".join(parts)

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -105,7 +105,13 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         if outcome.validation_passed and not failed:
             return PostModelPass(result=result)
 
-        return PostModelRetry(reason=_failure_reason(outcome.validation_summaries))
+        history = getattr(self.guard, "history", None)
+        return PostModelRetry(
+            reason=_failure_reason(
+                outcome.validation_summaries,
+                history.last if history else None,
+            )
+        )
 
 
 _FALLBACK_REASON = "validation failed"

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -64,9 +64,12 @@ class GuardrailsAIHook(AgentHook, BaseModel):
 
         def _validate() -> Any:
             with self._lock:
-                return self.guard.validate(raw)
+                return self.guard.validate(raw, num_reasks=0)
 
-        outcome = await asyncio.to_thread(_validate)
+        try:
+            outcome = await asyncio.to_thread(_validate)
+        except Exception as exc:  # noqa: BLE001
+            return PostModelRetry(reason=f"guardrails validation error: {exc}")
 
         if outcome.validation_passed:
             return PostModelPass(result=result)

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -62,7 +62,12 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         # this hook instance do not race on that state.
         raw = result.output.raw
         if not raw or not raw.strip():
-            return PostModelPass(result=result)
+            # No text content: check tool call arguments instead (the LLM may
+            # have written content via tool calls, e.g. FilesystemTool).
+            tool_calls = result.output.tool_calls
+            if not tool_calls:
+                return PostModelPass(result=result)
+            raw = "\n".join(tc.function.arguments for tc in tool_calls)
 
         def _validate() -> Any:
             with self._lock:

--- a/src/ant_ai/hooks/integrations/guardrails_ai.py
+++ b/src/ant_ai/hooks/integrations/guardrails_ai.py
@@ -61,6 +61,8 @@ class GuardrailsAIHook(AgentHook, BaseModel):
         # reask counter). Serialize via _lock so concurrent callers sharing
         # this hook instance do not race on that state.
         raw = result.output.raw
+        if not raw or not raw.strip():
+            return PostModelPass(result=result)
 
         def _validate() -> Any:
             with self._lock:

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -68,24 +68,40 @@ async def test_pass_when_validation_succeeds():
 
 @pytest.mark.unit
 @pytest.mark.guardrailsai
-async def test_retry_when_validation_fails():
-    guard = _make_guard(passed=False, failure_reason="toxic content detected")
+async def test_retry_reason_format():
+    hook = GuardrailsAIHook(
+        guard=_make_guard(passed=False, failure_reason="toxic content detected")
+    )
+    decision = await hook.after_model(_llm_result("bad output"), ctx=None)
+    assert isinstance(decision, PostModelRetry)
+    assert decision.reason == "test: toxic content detected"
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_retry_reason_multiple_validators():
+    summaries = [
+        _MockSummary(validator_name="detect_pii", failure_reason="EMAIL_ADDRESS detected"),
+        _MockSummary(validator_name="toxic_language", failure_reason="toxicity score 0.92"),
+    ]
+    outcome = _MockOutcome(validation_passed=False, validation_summaries=summaries)
+    guard = MagicMock()
+    guard.validate.return_value = outcome
     hook = GuardrailsAIHook(guard=guard)
     decision = await hook.after_model(_llm_result("bad output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
-    assert "toxic content detected" in decision.reason
-    guard.validate.assert_called_once_with(ANY, num_reasks=0)
+    assert decision.reason == (
+        "detect_pii: EMAIL_ADDRESS detected; toxic_language: toxicity score 0.92"
+    )
 
 
 @pytest.mark.unit
 @pytest.mark.guardrailsai
 async def test_retry_reason_falls_back_when_no_summaries():
-    guard = _make_guard(passed=False)
-    hook = GuardrailsAIHook(guard=guard)
+    hook = GuardrailsAIHook(guard=_make_guard(passed=False))
     decision = await hook.after_model(_llm_result("bad output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
     assert decision.reason == "validation failed"
-    guard.validate.assert_called_once_with(ANY, num_reasks=0)
 
 
 @pytest.mark.unit

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -81,8 +81,12 @@ async def test_retry_reason_format():
 @pytest.mark.guardrailsai
 async def test_retry_reason_multiple_validators():
     summaries = [
-        _MockSummary(validator_name="detect_pii", failure_reason="EMAIL_ADDRESS detected"),
-        _MockSummary(validator_name="toxic_language", failure_reason="toxicity score 0.92"),
+        _MockSummary(
+            validator_name="detect_pii", failure_reason="EMAIL_ADDRESS detected"
+        ),
+        _MockSummary(
+            validator_name="toxic_language", failure_reason="toxicity score 0.92"
+        ),
     ]
     outcome = _MockOutcome(validation_passed=False, validation_summaries=summaries)
     guard = MagicMock()
@@ -133,7 +137,9 @@ async def test_retry_when_validation_passed_true_but_summaries_show_failure():
     guard = MagicMock()
     guard.validate.return_value = outcome
     hook = GuardrailsAIHook(guard=guard)
-    decision = await hook.after_model(_llm_result("contact me at foo@bar.com"), ctx=None)
+    decision = await hook.after_model(
+        _llm_result("contact me at foo@bar.com"), ctx=None
+    )
     assert isinstance(decision, PostModelRetry)
     assert "EMAIL_ADDRESS detected in output" in decision.reason
 

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -123,6 +123,20 @@ async def test_retry_when_validation_passed_true_but_summaries_show_failure():
 
 @pytest.mark.unit
 @pytest.mark.guardrailsai
+async def test_skips_empty_raw():
+    guard = _make_guard(passed=False, failure_reason="should not be called")
+    hook = GuardrailsAIHook(guard=guard)
+    result = StepResult(
+        output=LLMOutput(raw=""),
+        transition=Transition(action=TransitionAction.CONTINUE),
+    )
+    decision = await hook.after_model(result, ctx=None)
+    assert isinstance(decision, PostModelPass)
+    guard.validate.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
 async def test_skips_non_llm_output():
     guard = _make_guard(passed=True)
     hook = GuardrailsAIHook(guard=guard)

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -67,21 +67,34 @@ async def test_pass_when_validation_succeeds():
 @pytest.mark.unit
 @pytest.mark.guardrailsai
 async def test_retry_when_validation_fails():
-    hook = GuardrailsAIHook(
-        guard=_make_guard(passed=False, failure_reason="toxic content detected")
-    )
+    guard = _make_guard(passed=False, failure_reason="toxic content detected")
+    hook = GuardrailsAIHook(guard=guard)
     decision = await hook.after_model(_llm_result("bad output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
     assert "toxic content detected" in decision.reason
+    guard.validate.assert_called_once_with(ANY, num_reasks=0)
 
 
 @pytest.mark.unit
 @pytest.mark.guardrailsai
 async def test_retry_reason_falls_back_when_no_summaries():
-    hook = GuardrailsAIHook(guard=_make_guard(passed=False))
+    guard = _make_guard(passed=False)
+    hook = GuardrailsAIHook(guard=guard)
     decision = await hook.after_model(_llm_result("bad output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
     assert decision.reason == "validation failed"
+    guard.validate.assert_called_once_with(ANY, num_reasks=0)
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_retry_when_validate_raises():
+    guard = MagicMock()
+    guard.validate.side_effect = RuntimeError("internal guardrails error")
+    hook = GuardrailsAIHook(guard=guard)
+    decision = await hook.after_model(_llm_result("some output"), ctx=None)
+    assert isinstance(decision, PostModelRetry)
+    assert "guardrails validation error" in decision.reason
 
 
 @pytest.mark.unit

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, MagicMock
 
 import pytest
 
+from ant_ai.core.message import ToolCall, ToolFunction
 from ant_ai.core.result import (
     LLMOutput,
     StepResult,
@@ -123,7 +124,8 @@ async def test_retry_when_validation_passed_true_but_summaries_show_failure():
 
 @pytest.mark.unit
 @pytest.mark.guardrailsai
-async def test_skips_empty_raw():
+async def test_skips_empty_raw_with_no_tool_calls():
+    # Empty raw AND no tool calls → nothing to validate, pass through.
     guard = _make_guard(passed=False, failure_reason="should not be called")
     hook = GuardrailsAIHook(guard=guard)
     result = StepResult(
@@ -133,6 +135,32 @@ async def test_skips_empty_raw():
     decision = await hook.after_model(result, ctx=None)
     assert isinstance(decision, PostModelPass)
     guard.validate.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_validates_tool_call_arguments_when_raw_empty():
+    # Empty raw BUT tool calls present → validate the serialized arguments so
+    # that content written via tools (e.g. FilesystemTool) is still checked.
+    guard = _make_guard(passed=False, failure_reason="EMAIL_ADDRESS detected")
+    hook = GuardrailsAIHook(guard=guard)
+    tc = ToolCall(
+        id="c1",
+        function=ToolFunction(
+            name="filesystem_tool",
+            arguments='{"path": "out.py", "content": "Author: foo@bar.com"}',
+        ),
+    )
+    result = StepResult(
+        output=LLMOutput(raw="", tool_calls=(tc,)),
+        transition=Transition(action=TransitionAction.CONTINUE),
+    )
+    decision = await hook.after_model(result, ctx=None)
+    assert isinstance(decision, PostModelRetry)
+    assert "EMAIL_ADDRESS detected" in decision.reason
+    guard.validate.assert_called_once_with(
+        '{"path": "out.py", "content": "Author: foo@bar.com"}', num_reasks=0
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/hooks/test_guardrails_ai.py
+++ b/tests/unit/hooks/test_guardrails_ai.py
@@ -27,6 +27,7 @@ def _llm_result(raw: str) -> StepResult:
 class _MockSummary:
     validator_name: str
     failure_reason: str | None
+    validator_status: str = "fail"
 
 
 @dataclass
@@ -95,6 +96,29 @@ async def test_retry_when_validate_raises():
     decision = await hook.after_model(_llm_result("some output"), ctx=None)
     assert isinstance(decision, PostModelRetry)
     assert "guardrails validation error" in decision.reason
+
+
+@pytest.mark.unit
+@pytest.mark.guardrailsai
+async def test_retry_when_validation_passed_true_but_summaries_show_failure():
+    # Guardrails quirk: on_fail="reask" + num_reasks=0 returns validation_passed=True
+    # even though validators failed. The hook must detect this via validator_status.
+    outcome = _MockOutcome(
+        validation_passed=True,
+        validation_summaries=[
+            _MockSummary(
+                validator_name="DetectPII",
+                failure_reason="EMAIL_ADDRESS detected in output",
+                validator_status="fail",
+            )
+        ],
+    )
+    guard = MagicMock()
+    guard.validate.return_value = outcome
+    hook = GuardrailsAIHook(guard=guard)
+    decision = await hook.after_model(_llm_result("contact me at foo@bar.com"), ctx=None)
+    assert isinstance(decision, PostModelRetry)
+    assert "EMAIL_ADDRESS detected in output" in decision.reason
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & Why

GuardrailsAIHook was producing spurious "validation failed" errors whenever the LLM responded with a tool call (e.g. FilesystemTool) instead of plain text, because guard.validate("") always returns validation_passed=False with empty summaries — regardless of whether any validator actually triggered. This consumed the entire retry budget on a false positive, preventing real PII/toxicity detection from ever running. Two additional fixes harden the hook against a guardrails quirk with on_fail="reask" and against uncaught exceptions from guard.validate().

## Changes

Empty-raw fallback: when result.output.raw is empty (LLM issued a tool call), validate the serialized tool call arguments instead so content written via tools is still inspected before execution; skip validation entirely when raw is empty and no tool calls are present
num_reasks=0: pass num_reasks=0 explicitly to guard.validate() to prevent guardrails' internal reask loop from discarding validation_summaries and causing the failure reason to fall back to the generic string
on_fail="reask" quirk: with num_reasks=0, guardrails sets validation_passed=True even when validators failed; detect real failures by checking validator_status == "fail" in summaries
Exception handling: wrap guard.validate() in try/except and return PostModelRetry(reason="guardrails validation error: ...") instead of letting the exception propagate
Tests: renamed test_retry_when_validation_fails → test_retry_reason_format with exact-match assertion; added test_retry_reason_multiple_validators to cover the multi-validator join path; removed redundant assert_called_once_with from test_retry_reason_falls_back_when_no_summaries

## Release

<!-- Apply a bump label if this PR should cut a release, otherwise skip. -->

- [x] `bump:patch` — bug fix