### PR TITLE
fix(history-compression): prevent orphaned ToolCallMessage in checkpoint

### DIFF
--- a/src/ant_ai/core/__init__.py
+++ b/src/ant_ai/core/__init__.py
@@ -25,6 +25,7 @@ from ant_ai.core.message import (
     ToolCallMessage,
     ToolCallResultMessage,
     ToolFunction,
+    sanitize_messages,
 )
 from ant_ai.core.response import ChatLLMResponse, ChatLLMStreamChunk
 from ant_ai.core.result import (
@@ -69,6 +70,7 @@ __all__ = [
     "ToolFunction",
     "ToolCall",
     "AnyMessage",
+    "sanitize_messages",
     # response
     "ChatLLMResponse",
     "ChatLLMStreamChunk",

--- a/src/ant_ai/core/message.py
+++ b/src/ant_ai/core/message.py
@@ -94,3 +94,31 @@ type AnyMessage = Annotated[
     Field(discriminator="kind"),
 ]
 """Type alias for any message type in the system, discriminated by the `_kind` field."""
+
+
+def sanitize_messages(messages: list[Message]) -> list[Message]:
+    """Return a copy of *messages* with every incomplete tool-call group removed.
+
+    An incomplete group is a ``ToolCallMessage`` whose immediately-following
+    ``role="tool"`` messages are fewer than the number of ``tool_calls`` it
+    declares.  Such groups cause OpenAI-compatible APIs to reject the request
+    with a 400 error.
+
+    Complete groups and all non-tool-call messages are preserved in order.
+    """
+    result: list[Message] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if isinstance(msg, ToolCallMessage):
+            n_calls = len(msg.tool_calls)
+            j = i + 1
+            while j < len(messages) and messages[j].role == "tool":
+                j += 1
+            if j - (i + 1) >= n_calls:
+                result.extend(messages[i:j])
+            i = j
+        else:
+            result.append(msg)
+            i += 1
+    return result

--- a/src/ant_ai/hooks/builtins/history_compression.py
+++ b/src/ant_ai/hooks/builtins/history_compression.py
@@ -4,7 +4,12 @@ from typing import Any, ClassVar, Self
 
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation, model_validator
 
-from ant_ai.core.message import Message, ToolCallMessage
+from ant_ai.core.message import (
+    Message,
+    ToolCallMessage,
+    ToolCallResultMessage,
+    sanitize_messages,
+)
 from ant_ai.core.types import InvocationContext, State
 from ant_ai.hooks.protocol import AgentHook
 
@@ -13,6 +18,24 @@ _SUMMARISE_PROMPT = (
     "Summarise the following conversation history concisely, "
     "preserving key facts, decisions, and context:\n\n"
 )
+
+
+def _message_text(m: Message) -> str:
+    """Return a human-readable single-line representation of a message.
+
+    Plain messages use ``role: content``.  Tool calls list function names and
+    their arguments so the summariser sees what was invoked, not an empty line.
+    Tool results prefix the tool name so the summariser can match call to result.
+    """
+    if isinstance(m, ToolCallMessage):
+        calls = "; ".join(
+            f"{tc.function.name}({tc.function.arguments})" for tc in m.tool_calls
+        )
+        prefix = f"{m.content} " if m.content else ""
+        return f"assistant: {prefix}[tool calls]: {calls}"
+    if isinstance(m, ToolCallResultMessage):
+        return f"tool [{m.name}]: {m.content or ''}"
+    return f"{m.role}: {m.content or ''}"
 
 
 class HistoryCompressionHook(AgentHook, BaseModel):
@@ -77,7 +100,7 @@ class HistoryCompressionHook(AgentHook, BaseModel):
 
     def _estimate_tokens(self, messages: list[Message]) -> int:
         """Rough estimate: 1 token ≈ 4 characters."""
-        return sum(len(m.content or "") for m in messages) // 4
+        return sum(len(_message_text(m)) for m in messages) // 4
 
     def _should_compress(self, messages: list[Message]) -> bool:
         if self.max_messages is not None and len(messages) >= self.max_messages:
@@ -88,13 +111,18 @@ class HistoryCompressionHook(AgentHook, BaseModel):
                 return True
         return False
 
+    def _sanitize(self, messages: list[Message]) -> list[Message]:
+        return sanitize_messages(messages)
+
     async def before_model(self, state: State, ctx: InvocationContext | None) -> None:
-        """Compress older history when either threshold is exceeded.
+        """Sanitize history and compress when a threshold is exceeded.
 
         Args:
             state: Current agent state whose ``messages`` may be compressed.
             ctx: Invocation context, or None if not available.
         """
+        state.messages = self._sanitize(state.messages)
+
         messages: list[Message] = state.messages
         if len(messages) <= self.keep_last or not self._should_compress(messages):
             return
@@ -104,29 +132,13 @@ class HistoryCompressionHook(AgentHook, BaseModel):
             len(messages) - self.keep_last if self.keep_last > 0 else len(messages)
         )
 
-        # Slide left: never orphan a ToolCallResultMessage at the head of `keep`.
-        # A `tool` role message must always be preceded by an assistant message with
-        # tool_calls; slide left until the boundary no longer bisects such a group.
+        # Slide left: never bisect a tool-result group at the boundary.  A tool
+        # role message must always be preceded by its ToolCallMessage; slide left
+        # until the boundary lands on the call or on a non-tool message.
+        # After _sanitize every ToolCallMessage in the list has complete results,
+        # so no slide-right is needed.
         while 0 < keep_from < len(messages) and messages[keep_from].role == "tool":
             keep_from -= 1
-
-        # Slide right: if the boundary lands on a ToolCallMessage whose results are
-        # absent or incomplete (e.g. broken A2A history or partial parallel calls),
-        # absorb the whole group into `to_compress` so it is summarised away instead
-        # of producing an invalid call.  For parallel tool calls, ALL N results must
-        # immediately follow — so compare the consecutive result count against the
-        # number of tool_calls in the message.
-        while keep_from < len(messages) and isinstance(
-            messages[keep_from], ToolCallMessage
-        ):
-            n_calls = len(messages[keep_from].tool_calls)
-            j = keep_from + 1
-            while j < len(messages) and messages[j].role == "tool":
-                j += 1
-            n_results = j - (keep_from + 1)
-            if n_results >= n_calls:
-                break  # Enough results follow — valid group, keep it.
-            keep_from = j  # Partial or absent results → absorb group into to_compress.
 
         to_compress: list[Message] = messages[:keep_from]
         keep: list[Message] = messages[keep_from:]
@@ -136,9 +148,7 @@ class HistoryCompressionHook(AgentHook, BaseModel):
         if not to_compress:
             return
 
-        history_text: str = "\n".join(
-            f"{m.role}: {m.content or ''}" for m in to_compress
-        )
+        history_text: str = "\n".join(_message_text(m) for m in to_compress)
         summary_request: list[Message] = [
             Message(role="user", content=f"{_SUMMARISE_PROMPT}{history_text}")
         ]
@@ -150,6 +160,9 @@ class HistoryCompressionHook(AgentHook, BaseModel):
             Message(role="system", content=f"{_SUMMARY_PREFIX}{summary}"),
             *keep,
         ]
-        # Record the compressed baseline (everything before the current user message)
+        # Record the compressed baseline (everything before the current trigger message)
         # so transport layers can persist it for durability across turns.
-        state._compression_context = list(state.messages[:-1])
+        # sanitize_messages removes any tool-call group whose result is the trigger
+        # (the last message), which would otherwise leave an orphaned ToolCallMessage
+        # in the persisted checkpoint and cause a 400 on the next turn.
+        state._compression_context = sanitize_messages(list(state.messages[:-1]))

--- a/tests/unit/hooks/test_history_compression.py
+++ b/tests/unit/hooks/test_history_compression.py
@@ -438,15 +438,12 @@ async def test_keep_last_zero_no_orphaned_tool_messages():
 
 
 @pytest.mark.unit
-async def test_orphaned_tool_call_at_boundary_slides_into_to_compress():
-    """If keep would start with a ToolCallMessage not followed by a result, slide it right into to_compress."""
+async def test_orphaned_tool_call_removed_by_sanitize():
+    """An orphaned ToolCallMessage is removed by _sanitize before the compression check."""
     llm = _CapturingLLM("summary")
     hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=3)
 
-    # [user1, ToolCallMessage(call_X), user2, user3]  — no tool result (invalid history)
-    # keep_last=3 → keep_from=1 → messages[1]=ToolCallMessage, messages[2]=user (not tool)
-    # RIGHT slide: keep_from → 2
-    # to_compress=[user1, ToolCallMessage], keep=[user2, user3]
+    # After _sanitize the orphaned call is gone, leaving 3 messages — below threshold.
     call = ToolCallMessage(
         tool_calls=[
             ToolCall(id="call_X", function=ToolFunction(name="t", arguments="{}"))
@@ -460,21 +457,17 @@ async def test_orphaned_tool_call_at_boundary_slides_into_to_compress():
 
     await hook.before_model(state, ctx=None)
 
-    assert llm.calls
+    assert not llm.calls  # threshold not met after sanitize
     _assert_valid_tool_sequence(state.messages)
     assert all(not isinstance(m, ToolCallMessage) for m in state.messages)
 
 
 @pytest.mark.unit
-async def test_orphaned_tool_call_as_last_message_slides_into_to_compress():
-    """A ToolCallMessage at the very end of keep (no following message) is moved to to_compress."""
+async def test_orphaned_tool_call_as_last_message_removed_by_sanitize():
+    """A ToolCallMessage at the very end with no result is dropped by _sanitize."""
     llm = _CapturingLLM("summary")
     hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=1)
 
-    # [user1, user2, user3, ToolCallMessage(call_X)]  — tool call is last message, no result
-    # keep_last=1 → keep_from=3 → messages[3]=ToolCallMessage, nothing follows
-    # RIGHT slide: keep_from → 4 = len(messages)
-    # to_compress = all, keep = []
     call = ToolCallMessage(
         tool_calls=[
             ToolCall(id="call_X", function=ToolFunction(name="t", arguments="{}"))
@@ -488,9 +481,9 @@ async def test_orphaned_tool_call_as_last_message_slides_into_to_compress():
 
     await hook.before_model(state, ctx=None)
 
-    assert llm.calls
-    assert len(state.messages) == 1
-    assert state.messages[0].role == "system"
+    assert not llm.calls  # threshold not met after sanitize
+    assert len(state.messages) == 3
+    assert all(not isinstance(m, ToolCallMessage) for m in state.messages)
 
 
 @pytest.mark.unit
@@ -556,18 +549,18 @@ async def test_parallel_tool_calls_all_results_kept_intact():
     assert llm.calls
     _assert_valid_tool_sequence(state.messages)
     assert any(isinstance(m, ToolCallMessage) for m in state.messages)
-    assert sum(1 for m in state.messages if m.role == "tool") == 2
+    assert (
+        sum(1 for m in state.messages if m.role == "tool") == 2
+    )  # both results in keep
 
 
 @pytest.mark.unit
-async def test_parallel_tool_calls_partial_results_slides_into_to_compress():
-    """ToolCallMessage with 2 calls but only 1 result: whole group absorbed into to_compress."""
+async def test_parallel_tool_calls_partial_results_removed_by_sanitize():
+    """ToolCallMessage with 2 calls but only 1 result: whole group dropped by _sanitize."""
     llm = _CapturingLLM("summary")
     hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=3)
 
-    # [user1, ToolCallMessage([A,B]), ToolResult(A), user2]  — missing ToolResult(B)
-    # keep_last=3 → keep_from=1 → ToolCallMessage has 2 calls but only 1 result
-    # RIGHT slide: n_calls=2, n_results=1 → absorb: keep_from=3
+    # After _sanitize the incomplete group is gone, leaving 2 messages — below threshold.
     tcm, results = _make_parallel_tool_group(2)
     state = State()
     state.add_message(Message(role="user", content="user1"))
@@ -577,9 +570,8 @@ async def test_parallel_tool_calls_partial_results_slides_into_to_compress():
 
     await hook.before_model(state, ctx=None)
 
-    assert llm.calls
+    assert not llm.calls  # threshold not met after sanitize
     _assert_valid_tool_sequence(state.messages)
-    # ToolCallMessage and the partial result both absorbed into summary
     assert not any(isinstance(m, ToolCallMessage) for m in state.messages)
     assert not any(m.role == "tool" for m in state.messages)
 
@@ -593,7 +585,6 @@ async def test_parallel_tool_calls_left_slide_keeps_full_group():
     # [user1, ToolCallMessage([A,B]), ToolResult(A), ToolResult(B), user2]
     # keep_last=2 → keep_from=3 → messages[3]=ToolResult(B) (role=tool)
     # LEFT slide: 3→2 (ToolResult A, still tool), 2→1 (ToolCallMessage, not tool) → stop
-    # RIGHT slide: messages[1] is ToolCallMessage, n_calls=2, n_results=2 → break
     # keep=[ToolCallMessage, ToolResult(A), ToolResult(B), user2]
     tcm, results = _make_parallel_tool_group(2)
     state = State()
@@ -609,3 +600,178 @@ async def test_parallel_tool_calls_left_slide_keeps_full_group():
     _assert_valid_tool_sequence(state.messages)
     assert any(isinstance(m, ToolCallMessage) for m in state.messages)
     assert sum(1 for m in state.messages if m.role == "tool") == 2
+
+
+# ---------------------------------------------------------------------------
+# _sanitize — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def _tc(call_id: str = "id-1", name: str = "t") -> ToolCall:
+    return ToolCall(id=call_id, function=ToolFunction(name=name, arguments="{}"))
+
+
+def _hook() -> HistoryCompressionHook:
+    return HistoryCompressionHook(llm=_CapturingLLM(), max_messages=100)
+
+
+@pytest.mark.unit
+def test_sanitize_removes_orphaned_tool_call():
+    messages = [
+        Message(role="user", content="hi"),
+        ToolCallMessage(tool_calls=[_tc()]),
+        Message(role="user", content="next"),
+    ]
+    result = _hook()._sanitize(messages)
+    assert [m.content for m in result] == ["hi", "next"]
+
+
+@pytest.mark.unit
+def test_sanitize_removes_lone_trailing_tool_call():
+    messages = [
+        Message(role="user", content="hi"),
+        ToolCallMessage(tool_calls=[_tc()]),
+    ]
+    result = _hook()._sanitize(messages)
+    assert result == [messages[0]]
+
+
+@pytest.mark.unit
+def test_sanitize_preserves_complete_group():
+    messages = [
+        ToolCallMessage(tool_calls=[_tc()]),
+        ToolCallResultMessage(tool_call_id="id-1", name="t", content="r"),
+        Message(role="assistant", content="done"),
+    ]
+    assert _hook()._sanitize(messages) == messages
+
+
+@pytest.mark.unit
+def test_sanitize_preserves_parallel_complete_group():
+    messages = [
+        ToolCallMessage(tool_calls=[_tc("a"), _tc("b")]),
+        ToolCallResultMessage(tool_call_id="a", name="t", content="r1"),
+        ToolCallResultMessage(tool_call_id="b", name="t", content="r2"),
+    ]
+    assert _hook()._sanitize(messages) == messages
+
+
+@pytest.mark.unit
+def test_sanitize_drops_partial_parallel_group():
+    messages = [
+        ToolCallMessage(tool_calls=[_tc("a"), _tc("b")]),
+        ToolCallResultMessage(tool_call_id="a", name="t", content="r1"),
+        Message(role="user", content="after"),
+    ]
+    result = _hook()._sanitize(messages)
+    assert result == [messages[-1]]
+
+
+@pytest.mark.unit
+async def test_sanitize_runs_unconditionally_below_compression_threshold():
+    """_sanitize fires even when history is well below the compression threshold."""
+    llm = _CapturingLLM()
+    hook = HistoryCompressionHook(llm=llm, max_messages=100, keep_last=2)
+
+    state = State()
+    state.add_message(ToolCallMessage(tool_calls=[_tc()]))  # orphaned — no result
+    state.add_message(Message(role="user", content="hi"))
+
+    await hook.before_model(state, ctx=None)
+
+    assert not llm.calls  # compression didn't trigger
+    assert len(state.messages) == 1
+    assert state.messages[0].content == "hi"
+
+
+# ---------------------------------------------------------------------------
+# _compression_context regression tests
+# ---------------------------------------------------------------------------
+# When compression fires mid-turn (e.g. after a tool call within the same turn),
+# state.messages[-1] is a ToolCallResultMessage.  Taking [:-1] to build
+# _compression_context would leave an orphaned ToolCallMessage in the persisted
+# checkpoint, causing a 400 on the very next request.
+
+
+@pytest.mark.unit
+async def test_compression_context_not_orphaned_when_last_message_is_tool_result():
+    """Compression after a tool call must not leave an orphaned TCM in the checkpoint.
+
+    Scenario: compression fires for the second model call in a turn.
+      state.messages = [prior_summary, user_msg, TCM, TCRM]   (TCRM is last)
+      After compression keep=[TCM, TCRM], so state.messages = [new_summary, TCM, TCRM].
+      Old bug: _compression_context = [new_summary, TCM]  ← orphaned!
+      Fix:     sanitize_messages removes the dangling TCM.
+    """
+    llm = _CapturingLLM("summary2")
+    hook = HistoryCompressionHook(llm=llm, max_messages=4, keep_last=2)
+
+    call, result = _make_tool_group()
+    state = State()
+    state.add_message(Message(role="system", content="[Conversation summary] prior"))
+    state.add_message(Message(role="user", content="do something"))
+    state.add_message(call)
+    state.add_message(result)  # TCRM is state.messages[-1]
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls, "compression should have fired"
+    assert state._compression_context is not None
+    _assert_valid_tool_sequence(state._compression_context)
+    assert not any(
+        isinstance(m, ToolCallMessage) for m in state._compression_context
+    ), "_compression_context must not contain an orphaned ToolCallMessage"
+
+
+@pytest.mark.unit
+async def test_compression_context_not_orphaned_with_parallel_tool_calls():
+    """Same regression with parallel calls: dropping the last TCRM leaves TCM with only one result."""
+    llm = _CapturingLLM("summary2")
+    hook = HistoryCompressionHook(llm=llm, max_messages=5, keep_last=3)
+
+    # state = [summary, user, TCM([A,B]), TCRM(A), TCRM(B)]
+    # keep_from=2 → no slide (TCM is assistant) → keep=[TCM, TCRM(A), TCRM(B)]
+    # after compress: [new_summary, TCM([A,B]), TCRM(A), TCRM(B)]
+    # [:-1] without fix = [new_summary, TCM([A,B]), TCRM(A)] — only 1 of 2 results → incomplete!
+    tcm, results = _make_parallel_tool_group(2)
+    state = State()
+    state.add_message(Message(role="system", content="[Conversation summary] prior"))
+    state.add_message(Message(role="user", content="do something"))
+    state.add_message(tcm)
+    state.add_message(results[0])
+    state.add_message(results[1])  # second TCRM is state.messages[-1]
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls, "compression should have fired"
+    assert state._compression_context is not None
+    _assert_valid_tool_sequence(state._compression_context)
+    assert not any(isinstance(m, ToolCallMessage) for m in state._compression_context)
+
+
+@pytest.mark.unit
+async def test_compression_context_keeps_complete_pair_when_last_is_non_tool():
+    """When the last kept message is NOT a tool result, a complete pair stays in the checkpoint."""
+    llm = _CapturingLLM("summary")
+    hook = HistoryCompressionHook(llm=llm, max_messages=6, keep_last=3)
+
+    # state = [u1, u2, u3, TCM, TCRM, user_final]
+    # keep_from=3 → messages[3]=TCM (assistant, not tool) → keep=[TCM, TCRM, user_final]
+    # after compress: [summary, TCM, TCRM, user_final]
+    # [:-1] = [summary, TCM, TCRM] — complete pair, should be preserved
+    call, result = _make_tool_group()
+    state = State()
+    for i in range(3):
+        state.add_message(Message(role="user", content=f"user{i}"))
+    state.add_message(call)
+    state.add_message(result)
+    state.add_message(Message(role="user", content="final"))  # user message is last
+
+    await hook.before_model(state, ctx=None)
+
+    assert llm.calls
+    assert state._compression_context is not None
+    _assert_valid_tool_sequence(state._compression_context)
+    # The complete pair should be retained in the checkpoint
+    assert any(isinstance(m, ToolCallMessage) for m in state._compression_context)
+    assert any(m.role == "tool" for m in state._compression_context)


### PR DESCRIPTION
## What & Why

`HistoryCompressionHook` was setting `state._compression_context = list(state.messages[:-1])` after compression. When compression fires mid-turn (after a tool call), the last message is a `ToolCallResultMessage` — taking `[:-1]` leaves an orphaned `ToolCallMessage` in the persisted checkpoint. On the next turn, `_build_history` merges that checkpoint with `post_a2a` which replays the full tool sequence, producing a duplicate orphaned `TCM` and an OpenAI 400 error. Additionally, tool calls were serialised as empty `assistant: ` lines in the summariser prompt, producing poor-quality summaries.

## Changes

- Added `sanitize_messages()` public utility to `ant_ai.core.message` that strips `ToolCallMessage` groups whose results are absent or incomplete; exported via `ant_ai.core`
- `HistoryCompressionHook`: replaced the slide-right boundary heuristic with an unconditional `_sanitize` pass at the top of `before_model`, so orphaned tool calls are removed before compression thresholds are evaluated
- `HistoryCompressionHook`: apply `sanitize_messages` when writing `state._compression_context` so the persisted checkpoint never contains an orphaned `ToolCallMessage`
- `HistoryCompressionHook`: added `_message_text()` helper so tool calls and results appear as readable lines in the summariser prompt; used in `_estimate_tokens` as well
- Expanded tests: updated boundary-slide tests to reflect new behaviour, added direct `_sanitize` unit tests, and three `_compression_context` regression tests covering the mid-turn tool-call scenario

## Closes

Closes #

## Release

- [x] `bump:patch` — bug fix
- [ ] `bump:minor` — new functionality
- [ ] `bump:major` — breaking change

## Docs

`sanitize_messages` is a new public API — docstring added inline. No docs page changes needed.