### PR TITLE
fix(a2a): type Colony.agent workflow param as Workflow[Any]

### DIFF
--- a/src/ant_ai/a2a/colony.py
+++ b/src/ant_ai/a2a/colony.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from urllib.parse import urlparse
 
 from a2a.server.tasks import DatabaseTaskStore, InMemoryTaskStore, TaskStore
@@ -62,7 +63,7 @@ class Colony(BaseModel):
         name: str,
         *,
         agent: Agent,
-        workflow: Workflow,
+        workflow: Workflow[Any],
         card: AgentCard,
     ) -> Colony:
         """Adds an agent to the colony.


### PR DESCRIPTION
## What & Why

`Colony.agent()` typed its `workflow` parameter as bare `Workflow`, which resolves to `Workflow[State]` (its PEP 696 default). Since generics are invariant, passing `Workflow[CustomState]` (a `Workflow` parameterized with a custom `State` subclass) triggered a type-checker warning at call sites even though it's perfectly valid at runtime.

## Changes

- Changed `Colony.agent()`'s `workflow` parameter from `Workflow` to `Workflow[Any]` in [src/ant_ai/a2a/colony.py](src/ant_ai/a2a/colony.py). The workflow is only ever stored in `AgentSpec` and forwarded opaquely to `A2AServer`/`A2AExecutor` — it's never operated on for its specific state type — so `Workflow[Any]` accepts any state type without weakening type safety elsewhere.

## Closes

Closes #

## Release

- [x] `bump:patch` — bug fix
- [ ] `bump:minor` — new functionality
- [ ] `bump:major` — breaking change

## Docs

Not applicable — no public API behaviour changed, only a type annotation.