### PR TITLE
fix(workflow): resolve router destinations from Literal annotation

### DIFF
--- a/src/ant_ai/workflow/visualize.py
+++ b/src/ant_ai/workflow/visualize.py
@@ -4,7 +4,7 @@ import ast
 import inspect
 import textwrap
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args, get_origin, get_type_hints
 
 from graphviz import Digraph
 
@@ -23,12 +23,22 @@ def _gv_id(name: str) -> str:
 
 
 def _router_destinations(router: RouterAction) -> list[str]:
-    """Return every literal string a router function can return, via AST.
+    """Return every destination a router function can route to.
 
-    Uses a depth-first visitor so results appear in source-code order.
-    Only direct string literals in ``return`` statements are collected;
-    variable references (e.g. ``return END``) are intentionally ignored.
+    Prefers the router's ``Literal[...]`` return-type annotation, since that
+    is the router's declared contract and survives dynamic return
+    expressions (ternaries, enum lookups, etc.) that a source-level scan
+    would miss. Falls back to an AST scan for direct string-literal
+    ``return`` statements when there is no ``Literal`` annotation.
     """
+    try:
+        hints = get_type_hints(router)
+    except Exception:
+        hints = {}
+    return_hint = hints.get("return")
+    if get_origin(return_hint) is Literal:
+        return list(get_args(return_hint))
+
     try:
         src = textwrap.dedent(inspect.getsource(router))
     except OSError:

--- a/tests/unit/workflow/test_visualize.py
+++ b/tests/unit/workflow/test_visualize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Literal
 
 import pytest
 
@@ -76,6 +77,24 @@ def test_router_destinations_ignores_non_literal_returns():
 
     dests = _router_destinations(router)
     assert dests == []
+
+
+@pytest.mark.unit
+def test_router_destinations_uses_literal_annotation_for_ternary():
+    def router(a, state, ctx) -> Literal["node_b", "node_c"]:
+        return "node_b" if True else "node_c"
+
+    dests = _router_destinations(router)
+    assert dests == ["node_b", "node_c"]
+
+
+@pytest.mark.unit
+def test_router_destinations_uses_literal_annotation_for_dynamic_return():
+    def router(a, state, ctx) -> Literal["node_b", "node_c"]:
+        return state.destination  # value only known at runtime
+
+    dests = _router_destinations(router)
+    assert dests == ["node_b", "node_c"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & Why

`build_workflow_graph` renders router diamonds as dead ends whenever a router's `return` statement isn't a bare string literal (a ternary, or a value computed at runtime). This produced a visually disconnected graph — reported when visualizing a codegen workflow where `route_action` and `code_presence_result` rendered as islands with no outgoing edges.

## Changes

- `_router_destinations` now reads the router's `Literal[...]` return-type annotation first (the router's declared destination contract), falling back to the existing AST scan for direct string-literal returns only when no `Literal` annotation is present.
- Added unit tests covering ternary-return and dynamic-return routers with a `Literal` annotation.

## Closes

N/A — reported directly in conversation, no tracking issue.

## Release

- [x] `bump:patch` — bug fix

## Docs

N/A — no public API surface changed, `_router_destinations` is a private helper.