### PR TITLE
docs: add CITATION.cff and citation section

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "ant-ai: A lightweight Python framework for building multi-agent AI systems"
+type: software
+authors:
+    - family-names: Sas
+      given-names: Cezar
+      email: cezar.sas@supsi.ch
+    - family-names: Giuffrida
+      given-names: Vincenzo
+      email: vincenzo.giuffrida@supsi.ch
+    - family-names: Mitrovic
+      given-names: Sandra
+      email: sandra.mitrovic@supsi.ch
+    - family-names: Salani
+      given-names: Matteo
+      email: matteo.salani@supsi.ch
+repository-code: "https://github.com/idea-idsia/ant-ai"
+url: "https://idea.idsia.ch/ant-ai/"
+license: MIT
+identifiers:
+    - type: doi
+      value: 10.5281/zenodo.21276625
+      description: "The DOI for all versions of ant-ai."

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/ant-ai?label=PyPI)
 [![Coverage](https://img.shields.io/codecov/c/github/idea-idsia/ant-ai?label=Coverage&logo=codecov)](https://codecov.io/gh/idea-idsia/ant-ai)
 [![Docs](https://img.shields.io/badge/Docs-mkdocs-526cfe?logo=materialformkdocs&logoColor=white)](https://idea.idsia.ch/ant-ai/)
+[![DOI](https://zenodo.org/badge/1219140757.svg)](https://doi.org/10.5281/zenodo.21276625)
 
 **A lightweight Python framework for building tool-driven AI agents and multi-agent systems.**
 
@@ -139,6 +140,19 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributing guide, branchin
 ## License
 
 This software is licensed under the MIT license. See the [LICENSE](LICENSE) file for details.
+
+## Citation
+
+If you use `ant-ai` in your research, please cite it. See [CITATION.cff](CITATION.cff) for the machine-readable citation metadata, or use the BibTeX entry below.
+
+```bibtex
+@software{ant_ai,
+  author  = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
+  title   = {ant-ai: A lightweight Python framework for building multi-agent AI systems},
+  url     = {https://github.com/idea-idsia/ant-ai},
+  doi     = {10.5281/zenodo.21276625}
+}
+```
 
 ## Funding
 

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -2,6 +2,7 @@ nav:
     - Home:
         - index.md
         - Funding: funding.md
+        - Citation: citation.md
     - Docs: docs
     - Reference:
           - Overview: reference/

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,16 @@
+---
+title: Citation
+---
+
+# Citation
+
+If you use `ant-ai` in your research, please cite it. See [CITATION.cff](https://github.com/idea-idsia/ant-ai/blob/main/CITATION.cff) for the machine-readable citation metadata, or use the BibTeX entry below.
+
+```bibtex
+@software{ant_ai,
+  author  = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
+  title   = {ant-ai: A lightweight Python framework for building multi-agent AI systems},
+  url     = {https://github.com/idea-idsia/ant-ai},
+  doi     = {10.5281/zenodo.21276625}
+}
+```


### PR DESCRIPTION
## Summary
- Add CITATION.cff with author/repository/license/DOI metadata
- Add a Citation section (with BibTeX) to the README and to the docs site (docs/citation.md), wired into nav
- Add the Zenodo DOI badge to the README

No functional/code changes - docs only, no version bump needed.

## Test plan
- [x] Verified CFF fields against pyproject.toml authors/license/repo
- [x] docs/citation.md mirrors existing funding.md structure and is registered in docs/.nav.yml

