### PR TITLE
docs: add .zenodo.json and author ORCIDs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+    "title": "ant-ai: A lightweight Python framework for building multi-agent AI systems",
+    "description": "A lightweight Python framework for building tool-driven AI agents and multi-agent systems: graph-based workflow orchestration, first-class agent-to-agent (A2A) communication, MCP tool integration, lifecycle hooks for guardrails, and built-in observability.",
+    "creators": [
+        {
+            "name": "Sas, Cezar",
+            "affiliation": "IDSIA USI-SUPSI",
+            "orcid": "0000-0002-3018-0140"
+        },
+        {
+            "name": "Giuffrida, Vincenzo",
+            "affiliation": "IDSIA USI-SUPSI",
+            "orcid": "0009-0009-4627-7391"
+        },
+        {
+            "name": "Mitrovic, Sandra",
+            "affiliation": "IDSIA USI-SUPSI",
+            "orcid": "0000-0002-5697-5865"
+        },
+        {
+            "name": "Salani, Matteo",
+            "affiliation": "IDSIA USI-SUPSI",
+            "orcid": "0000-0003-2809-4347"
+        }
+    ],
+    "upload_type": "software",
+    "access_right": "open",
+    "license": "MIT",
+    "keywords": [
+        "multi-agent systems",
+        "agentic-ai",
+        "llm",
+        "python"
+    ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,15 +6,19 @@ authors:
     - family-names: Sas
       given-names: Cezar
       email: cezar.sas@supsi.ch
+      orcid: "https://orcid.org/0000-0002-3018-0140"
     - family-names: Giuffrida
       given-names: Vincenzo
       email: vincenzo.giuffrida@supsi.ch
+      orcid: "https://orcid.org/0009-0009-4627-7391"
     - family-names: Mitrovic
       given-names: Sandra
       email: sandra.mitrovic@supsi.ch
+      orcid: "https://orcid.org/0000-0002-5697-5865"
     - family-names: Salani
       given-names: Matteo
       email: matteo.salani@supsi.ch
+      orcid: "https://orcid.org/0000-0003-2809-4347"
 repository-code: "https://github.com/idea-idsia/ant-ai"
 url: "https://idea.idsia.ch/ant-ai/"
 license: MIT

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ This software is licensed under the MIT license. See the [LICENSE](LICENSE) file
 If you use `ant-ai` in your research, please cite it. See [CITATION.cff](CITATION.cff) for the machine-readable citation metadata, or use the BibTeX entry below.
 
 ```bibtex
-@software{ant_ai,
-  author  = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
-  title   = {ant-ai: A lightweight Python framework for building multi-agent AI systems},
-  url     = {https://github.com/idea-idsia/ant-ai},
-  doi     = {10.5281/zenodo.21276625}
+@software{Sas_ant-ai_A_lightweight,
+author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
+license = {MIT},
+title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
+url = {https://github.com/idea-idsia/ant-ai}
 }
 ```
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -7,10 +7,10 @@ title: Citation
 If you use `ant-ai` in your research, please cite it. See [CITATION.cff](https://github.com/idea-idsia/ant-ai/blob/main/CITATION.cff) for the machine-readable citation metadata, or use the BibTeX entry below.
 
 ```bibtex
-@software{ant_ai,
-  author  = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
-  title   = {ant-ai: A lightweight Python framework for building multi-agent AI systems},
-  url     = {https://github.com/idea-idsia/ant-ai},
-  doi     = {10.5281/zenodo.21276625}
+@software{Sas_ant-ai_A_lightweight,
+author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
+license = {MIT},
+title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
+url = {https://github.com/idea-idsia/ant-ai}
 }
 ```


### PR DESCRIPTION
## Summary
- Add .zenodo.json with creators (name/affiliation/ORCID), license, and keywords for richer Zenodo metadata
- Add verified ORCIDs (from https://idea.idsia.ch/people/) to CITATION.cff for all four authors
- Align the README/docs BibTeX block with GitHub's auto-generated citation entry

Follow-up to #92, which merged before this commit was pushed.

## Test plan
- [x] ORCIDs cross-checked
- [x] .zenodo.json validated as JSON

