### PR TITLE
feat(workflow): add Mermaid output format for workflow rendering

### DIFF
--- a/docs/docs/single-agent/visualize.md
+++ b/docs/docs/single-agent/visualize.md
@@ -8,7 +8,7 @@ title: Visualizing Workflows
 
 ## Installation
 
-The visualizer wraps the [Graphviz](https://graphviz.org/) library. Install both the Python package and the system CLI:
+The `png`, `jpg`, `pdf`, `svg`, and `latex` formats wrap the [Graphviz](https://graphviz.org/) library. Install both the Python package and the system CLI:
 
 ```sh
 uv add ant-ai[viz]
@@ -19,6 +19,8 @@ brew install graphviz
 # Ubuntu / Debian
 sudo apt-get install graphviz
 ```
+
+The `mermaid` format has no such dependency — see [Mermaid output](#mermaid-output) below.
 
 ## Jupyter notebook
 
@@ -44,7 +46,37 @@ render_workflow(wf, "diagram", format="pdf")
 
 # LaTeX — produces a self-contained .tex file with a tikzpicture
 render_workflow(wf, "diagram", format="latex")
+
+# Mermaid — produces a .mmd file, no graphviz dependency required
+render_workflow(wf, "diagram", format="mermaid")
 ```
+
+### Mermaid output
+
+The `mermaid` format doesn't need the `graphviz` package or CLI at all — call
+[`build_workflow_mermaid()`][ant_ai.workflow.visualize.build_workflow_mermaid]
+directly to get the definition as a string, or use `render_workflow(..., format="mermaid")`
+to write a `diagram.mmd` file:
+
+```python
+from ant_ai.workflow import build_workflow_mermaid
+
+print(build_workflow_mermaid(wf))
+```
+
+```mermaid
+flowchart LR
+    n_START(["START"])
+    n_END(["END"])
+    n_A["A"]
+    n_START --> n_A
+    n_A --> n_END
+```
+
+Mermaid definitions render natively in GitHub, GitLab, and MkDocs Material
+(via `pymdownx.superfences`, already enabled for this site) — paste the
+output straight into a fenced ` ```mermaid ` code block in a README, PR
+description, or docs page.
 
 ### LaTeX output
 
@@ -71,6 +103,7 @@ The default layout is left-to-right (`rankdir="LR"`). Pass `rankdir="TB"` for a 
 
 ```python
 build_workflow_graph(wf)                          # left-to-right (default)
+build_workflow_mermaid(wf)                        # left-to-right (default)
 render_workflow(wf, "diagram", format="png")      # left-to-right (default)
 render_workflow(wf, "diagram", format="png", rankdir="TB")  # top-to-bottom
 ```

--- a/src/ant_ai/workflow/__init__.py
+++ b/src/ant_ai/workflow/__init__.py
@@ -1,5 +1,9 @@
 from ant_ai.workflow.action import BaseAction
-from ant_ai.workflow.visualize import build_workflow_graph, render_workflow
+from ant_ai.workflow.visualize import (
+    build_workflow_graph,
+    build_workflow_mermaid,
+    render_workflow,
+)
 from ant_ai.workflow.workflow import END, START, NodeYield, Workflow
 
 __all__ = [
@@ -9,5 +13,6 @@ __all__ = [
     "START",
     "NodeYield",
     "build_workflow_graph",
+    "build_workflow_mermaid",
     "render_workflow",
 ]

--- a/src/ant_ai/workflow/visualize.py
+++ b/src/ant_ai/workflow/visualize.py
@@ -10,7 +10,9 @@ from graphviz import Digraph
 
 from ant_ai.workflow.workflow import END, START, RouterAction, Workflow
 
-_FORMATS = ("png", "jpg", "pdf", "svg", "latex")
+type RenderFormat = Literal["png", "jpg", "pdf", "svg", "latex", "mermaid"]
+
+_FORMATS: tuple[RenderFormat, ...] = get_args(RenderFormat.__value__)
 
 _FILL_SPECIAL = "#d0e8ff"  # START / END
 _FILL_NODE = "#ffffff"  # regular nodes
@@ -20,6 +22,15 @@ _FILL_ROUTER = "#fff3cd"  # decision diamonds
 def _gv_id(name: str) -> str:
     """Stable single-token graphviz node id (no spaces)."""
     return name.replace(" ", "_").replace("-", "_")
+
+
+def _mmd_id(name: str) -> str:
+    """Stable Mermaid node id.
+
+    Prefixed so node names can never collide with Mermaid reserved words
+    (e.g. ``end``, matched case-insensitively) or its edge-hint syntax.
+    """
+    return "n_" + _gv_id(name)
 
 
 def _router_destinations(router: RouterAction) -> list[str]:
@@ -137,6 +148,54 @@ def build_workflow_graph(
     return g
 
 
+def build_workflow_mermaid(
+    workflow: Workflow,
+    *,
+    rankdir: str = "LR",
+) -> str:
+    """
+    Build a Mermaid ``flowchart`` definition for *workflow*.
+
+    Unlike :func:`build_workflow_graph`, this has no dependency on the
+    ``graphviz`` package or CLI — Mermaid does its own auto-layout, and the
+    result is plain text that renders natively in GitHub, GitLab, MkDocs
+    Material, and the Mermaid Live Editor.
+
+    Args:
+        workflow: The workflow to visualise.
+        rankdir: Layout direction — ``"LR"`` (left-to-right, default) or
+            ``"TB"`` (top-to-bottom). Passed through to Mermaid's
+            ``flowchart`` direction.
+
+    Returns:
+        A Mermaid ``flowchart`` definition as a string.
+    """
+    lines = [f"flowchart {rankdir}"]
+
+    # START / END — stadium shape
+    for special in (START, END):
+        lines.append(f'    {_mmd_id(special)}(["{special}"])')
+
+    # Regular nodes — rectangle
+    for name in workflow.nodes:
+        lines.append(f'    {_mmd_id(name)}["{name}"]')
+
+    # Static edges
+    for src, dst in workflow.edges.items():
+        lines.append(f"    {_mmd_id(src)} --> {_mmd_id(dst)}")
+
+    # Conditional edges — diamond + AST-extracted destinations
+    for src, router in workflow.conditional_edges.items():
+        diamond_id = f"r_{_gv_id(src)}"
+        router_label = getattr(router, "__name__", repr(router))
+        lines.append(f'    {diamond_id}{{"{router_label}"}}')
+        lines.append(f"    {_mmd_id(src)} --> {diamond_id}")
+        for dst in _router_destinations(router):
+            lines.append(f"    {diamond_id} -.-> {_mmd_id(dst)}")
+
+    return "\n".join(lines)
+
+
 _TIKZ_PREAMBLE = r"""\documentclass{standalone}
 \usepackage{tikz}
 \usetikzlibrary{shapes.geometric, arrows.meta, positioning}
@@ -251,7 +310,7 @@ def _build_tikz(workflow: Workflow, engine: str) -> str:
 def render_workflow(
     workflow: Workflow,
     path: str | Path,
-    format: Literal["png", "jpg", "pdf", "svg", "latex"] = "png",
+    format: RenderFormat = "png",
     *,
     engine: str = "dot",
     rankdir: str = "LR",
@@ -263,23 +322,32 @@ def render_workflow(
         workflow: The workflow to visualise.
         path: Output path. The file extension is set automatically based on
             *format* (any existing extension is replaced).
-        format: ``"png"``, ``"jpg"``, ``"pdf"``, ``"svg"``, or ``"latex"``.
-            The ``"latex"`` format produces a self-contained ``.tex`` file
-            that can be compiled with ``pdflatex``.
-        engine: Graphviz layout engine.
+        format: ``"png"``, ``"jpg"``, ``"pdf"``, ``"svg"``, ``"latex"``, or
+            ``"mermaid"``. The ``"latex"`` format produces a self-contained
+            ``.tex`` file that can be compiled with ``pdflatex``. The
+            ``"mermaid"`` format produces a ``.mmd`` file with a Mermaid
+            ``flowchart`` definition — no ``graphviz`` dependency required.
+        engine: Graphviz layout engine. Ignored for ``"mermaid"``.
         rankdir: Layout direction — ``"LR"`` (left-to-right, default) or ``"TB"``.
 
     Returns:
         :class:`~pathlib.Path` of the rendered file.
 
     Raises:
-        ImportError: if the ``graphviz`` package is not installed.
+        ImportError: if the ``graphviz`` package is not installed and
+            *format* requires it (i.e. not ``"latex"`` or ``"mermaid"``).
         ValueError: if *format* is not one of the supported values.
     """
     if format not in _FORMATS:
         raise ValueError(f"format must be one of {_FORMATS!r}, got {format!r}")
 
     out = Path(path)
+
+    if format == "mermaid":
+        mmd = build_workflow_mermaid(workflow, rankdir=rankdir)
+        dest = out.with_suffix(".mmd")
+        dest.write_text(mmd, encoding="utf-8")
+        return dest
 
     if format == "latex":
         tex = _build_tikz(workflow, engine=engine)

--- a/tests/unit/workflow/test_visualize.py
+++ b/tests/unit/workflow/test_visualize.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from typing import Literal
 
 import pytest
 
 from ant_ai.workflow.visualize import (
     _gv_id,
+    _mmd_id,
     _router_destinations,
     build_workflow_graph,
+    build_workflow_mermaid,
     render_workflow,
 )
 from ant_ai.workflow.workflow import Workflow
@@ -174,3 +177,81 @@ def test_build_workflow_graph_lr_rankdir(noop_workflow):
 def test_render_workflow_rejects_invalid_format(noop_workflow):
     with pytest.raises(ValueError, match="format must be one of"):
         render_workflow(noop_workflow, "/tmp/wf", format="bmp")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_mmd_id_passthrough():
+    assert _mmd_id("simple") == "n_simple"
+
+
+@pytest.mark.unit
+def test_mmd_id_normalizes_spaces_and_hyphens():
+    assert _mmd_id("my-cool node") == "n_my_cool_node"
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_no_graphviz_required(monkeypatch, noop_workflow):
+    monkeypatch.setitem(sys.modules, "graphviz", None)
+    # Should not raise even though graphviz is unavailable.
+    assert "flowchart" in build_workflow_mermaid(noop_workflow)
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_default_direction(noop_workflow):
+    src = build_workflow_mermaid(noop_workflow)
+    assert src.startswith("flowchart LR")
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_tb_direction(noop_workflow):
+    src = build_workflow_mermaid(noop_workflow, rankdir="TB")
+    assert src.startswith("flowchart TB")
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_start_end_are_stadiums(noop_workflow):
+    src = build_workflow_mermaid(noop_workflow)
+    assert 'n_START(["START"])' in src
+    assert 'n_END(["END"])' in src
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_regular_node_is_rectangle(noop_workflow):
+    assert 'n_A["A"]' in build_workflow_mermaid(noop_workflow)
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_static_edge(noop_workflow):
+    src = build_workflow_mermaid(noop_workflow)
+    assert "n_START --> n_A" in src
+    assert "n_A --> n_END" in src
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_conditional_creates_diamond(conditional_workflow):
+    assert 'r_A{"my_router"}' in build_workflow_mermaid(conditional_workflow)
+
+
+@pytest.mark.unit
+def test_build_workflow_mermaid_conditional_dashed_edges(conditional_workflow):
+    src = build_workflow_mermaid(conditional_workflow)
+    assert "r_A -.-> n_B" in src
+    assert "r_A -.-> n_END" in src
+
+
+@pytest.mark.unit
+def test_render_workflow_mermaid_writes_mmd_file(noop_workflow, tmp_path: Path):
+    out = render_workflow(noop_workflow, tmp_path / "wf", format="mermaid")
+    assert out.suffix == ".mmd"
+    assert out.exists()
+    text = out.read_text()
+    assert "flowchart LR" in text
+    assert "n_START" in text
+    assert "n_END" in text
+    assert "n_A" in text
+
+
+@pytest.mark.unit
+def test_render_workflow_mermaid_extension_replaced(noop_workflow, tmp_path: Path):
+    out = render_workflow(noop_workflow, tmp_path / "wf.txt", format="mermaid")
+    assert out.suffix == ".mmd"


### PR DESCRIPTION
## Summary

- Adds `build_workflow_mermaid()` and wires a `"mermaid"` format into `render_workflow()`, generating a Mermaid `flowchart` definition for a `Workflow` (`src/ant_ai/workflow/visualize.py`)
- Unlike the Graphviz-backed formats (`png`/`jpg`/`pdf`/`svg`) and the TikZ-backed `latex` format, `mermaid` needs no `graphviz` package/CLI at all — it's plain text, and Mermaid does its own layout
- Consolidated the format list into a single `RenderFormat` type alias (`_FORMATS` is now derived from it via `get_args`) instead of keeping the tuple and the `Literal[...]` signature in sync by hand
- Exported `build_workflow_mermaid` from `ant_ai.workflow`
- Docs updated in `docs/docs/single-agent/visualize.md`, including a live `mermaid` fenced block (already supported by this site's `pymdownx.superfences` config)

Closes #95

## Test plan

- [x] `uv run pytest tests/unit/workflow/test_visualize.py -v` — new unit tests for `_mmd_id`, `build_workflow_mermaid` (direction, node shapes, static/conditional edges, no-graphviz-required), and `render_workflow(..., format="mermaid")`
- [x] `uv run pytest -m "not vllm and not external" --cov` — full suite passes (474 passed)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run ty check`
- [x] `uv run mkdocs build` — docs build clean; verified the new `visualize.md` mermaid fence renders as `<pre class="mermaid">` in the built HTML and `build_workflow_mermaid` appears in the generated API reference