### PR TITLE
docs: fix Sandra Mitrović name spelling in citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -13,7 +13,7 @@
             "orcid": "0009-0009-4627-7391"
         },
         {
-            "name": "Mitrovic, Sandra",
+            "name": "Mitrović, Sandra",
             "affiliation": "IDSIA USI-SUPSI",
             "orcid": "0000-0002-5697-5865"
         },

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
       given-names: Vincenzo
       email: vincenzo.giuffrida@supsi.ch
       orcid: "https://orcid.org/0009-0009-4627-7391"
-    - family-names: Mitrovic
+    - family-names: Mitrović
       given-names: Sandra
       email: sandra.mitrovic@supsi.ch
       orcid: "https://orcid.org/0000-0002-5697-5865"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you use `ant-ai` in your research, please cite it. See [CITATION.cff](CITATIO
 
 ```bibtex
 @software{Sas_ant-ai_A_lightweight,
-author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
+author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
 license = {MIT},
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
 url = {https://github.com/idea-idsia/ant-ai}

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -8,7 +8,7 @@ If you use `ant-ai` in your research, please cite it. See [CITATION.cff](https:/
 
 ```bibtex
 @software{Sas_ant-ai_A_lightweight,
-author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrovic, Sandra and Salani, Matteo},
+author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
 license = {MIT},
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
 url = {https://github.com/idea-idsia/ant-ai}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.14"
 authors = [
     { name = "Cezar Sas", email = "cezar.sas@supsi.ch" },
     { name = "Vincenzo Giuffrida", email = "vincenzo.giuffrida@supsi.ch" },
-    { name = "Sandra Mitrovic", email = "sandra.mitrovic@supsi.ch" },
+    { name = "Sandra Mitrović", email = "sandra.mitrovic@supsi.ch" },
     { name = "Matteo Salani", email = "matteo.salani@supsi.ch" },
 ]
 


### PR DESCRIPTION
## What & Why

Corrects the spelling of Sandra Mitrović's surname (missing diacritic) across citation and package metadata files.

## Changes

- Fixed `Mitrovic` → `Mitrović` in `.zenodo.json`, `CITATION.cff`, `pyproject.toml`, `README.md`, and `docs/citation.md`

## Closes

Closes #

## Release

- [x] `bump:patch` — bug fix

## Docs

N/A