### PR TITLE
docs: add DOI and release year to citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,6 +24,7 @@
         }
     ],
     "upload_type": "software",
+    "publication_date": "2026-06-30",
     "access_right": "open",
     "license": "MIT",
     "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ repository-code: "https://github.com/idea-idsia/ant-ai"
 url: "https://idea.idsia.ch/ant-ai/"
 license: MIT
 doi: 10.5281/zenodo.21276625
-date-released: "2026-07-14"
+date-released: "2026-06-30"
 identifiers:
     - type: doi
       value: 10.5281/zenodo.21276625

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ repository-code: "https://github.com/idea-idsia/ant-ai"
 url: "https://idea.idsia.ch/ant-ai/"
 license: MIT
 doi: 10.5281/zenodo.21276625
-year: 2026
+date-released: "2026-07-14"
 identifiers:
     - type: doi
       value: 10.5281/zenodo.21276625

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,6 +22,8 @@ authors:
 repository-code: "https://github.com/idea-idsia/ant-ai"
 url: "https://idea.idsia.ch/ant-ai/"
 license: MIT
+doi: 10.5281/zenodo.21276625
+year: 2026
 identifiers:
     - type: doi
       value: 10.5281/zenodo.21276625

--- a/README.md
+++ b/README.md
@@ -146,13 +146,14 @@ This software is licensed under the MIT license. See the [LICENSE](LICENSE) file
 If you use `ant-ai` in your research, please cite it. See [CITATION.cff](CITATION.cff) for the machine-readable citation metadata, or use the BibTeX entry below.
 
 ```bibtex
-@software{Sas_ant-ai_A_lightweight,
+@software{Sas_ant-ai_A_lightweight_2026,
 author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
+doi = {10.5281/zenodo.21276625},
 license = {MIT},
+month = jul,
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
 url = {https://github.com/idea-idsia/ant-ai},
-year = {2026},
-doi = {10.5281/zenodo.21276625}
+year = {2026}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you use `ant-ai` in your research, please cite it. See [CITATION.cff](CITATIO
 author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
 doi = {10.5281/zenodo.21276625},
 license = {MIT},
-month = jul,
+month = jun,
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
 url = {https://github.com/idea-idsia/ant-ai},
 year = {2026}

--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ If you use `ant-ai` in your research, please cite it. See [CITATION.cff](CITATIO
 author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
 license = {MIT},
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
-url = {https://github.com/idea-idsia/ant-ai}
+url = {https://github.com/idea-idsia/ant-ai},
+year = {2026},
+doi = {10.5281/zenodo.21276625}
 }
 ```
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -11,7 +11,7 @@ If you use `ant-ai` in your research, please cite it. See [CITATION.cff](https:/
 author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
 doi = {10.5281/zenodo.21276625},
 license = {MIT},
-month = jul,
+month = jun,
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
 url = {https://github.com/idea-idsia/ant-ai},
 year = {2026}

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -11,6 +11,8 @@ If you use `ant-ai` in your research, please cite it. See [CITATION.cff](https:/
 author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
 license = {MIT},
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
-url = {https://github.com/idea-idsia/ant-ai}
+url = {https://github.com/idea-idsia/ant-ai},
+year = {2026},
+doi = {10.5281/zenodo.21276625}
 }
 ```

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -7,12 +7,13 @@ title: Citation
 If you use `ant-ai` in your research, please cite it. See [CITATION.cff](https://github.com/idea-idsia/ant-ai/blob/main/CITATION.cff) for the machine-readable citation metadata, or use the BibTeX entry below.
 
 ```bibtex
-@software{Sas_ant-ai_A_lightweight,
+@software{Sas_ant-ai_A_lightweight_2026,
 author = {Sas, Cezar and Giuffrida, Vincenzo and Mitrović, Sandra and Salani, Matteo},
+doi = {10.5281/zenodo.21276625},
 license = {MIT},
+month = jul,
 title = {{ant-ai: A lightweight Python framework for building multi-agent AI systems}},
 url = {https://github.com/idea-idsia/ant-ai},
-year = {2026},
-doi = {10.5281/zenodo.21276625}
+year = {2026}
 }
 ```


### PR DESCRIPTION
## What & Why

Adds DOI and release year to the project's citation metadata so `CITATION.cff` and the BibTeX examples in `README.md`/`docs/citation.md` are complete and consistent, and validated against the CFF 1.2.0 schema (checked with `cffconvert` and cross-referenced with GitHub's own CITATION.cff docs).

## Changes

- Added `doi` and `date-released` fields to `CITATION.cff` (top-level `year` is not a valid CFF field; `date-released` is the correct equivalent and both APA/BibTeX renderers derive the year from it)
- Added matching `doi`/`year`/`month` fields to the BibTeX examples in `README.md` and `docs/citation.md`
- Renamed the BibTeX citation key to `Sas_ant-ai_A_lightweight_2026` and aligned field order across both files

## Closes

Closes #

## Release

- [x] `bump:patch` — bug fix

## Docs

N/A