### PR TITLE
chore: bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           - id: detect-private-key
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.15.12
+      rev: v0.16.3
       hooks:
           - id: ruff-check
             types_or:
@@ -23,6 +23,6 @@ repos:
           - id: ruff-format
 
     - repo: https://github.com/betterleaks/betterleaks
-      rev: v1.4.0
+      rev: v1.8.1
       hooks:
           - id: betterleaks


### PR DESCRIPTION
## Summary
- Bump ruff-pre-commit from v0.15.12 to v0.16.3
- Bump betterleaks from v1.4.0 to v1.8.1

## Test plan
- [x] Pre-commit hooks run successfully with the updated versions