### PR TITLE
chore(ci): bump astral-sh/setup-uv to v10.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: "3.14"
                   enable-cache: true
@@ -28,7 +28,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: "3.14"
                   enable-cache: true
@@ -42,7 +42,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: "3.14"
                   enable-cache: true
@@ -90,7 +90,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: "3.14"
                   enable-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: "3.14"
                   enable-cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
                   ref: main
                   token: ${{ secrets.RELEASE_PAT }}
 
-            - uses: astral-sh/setup-uv@v8.2.0
+            - uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: "3.14"
                   enable-cache: true


### PR DESCRIPTION
## Summary
- Bump `astral-sh/setup-uv` from `v8.2.0` to `v10.0.1` across all workflows (`ci.yml`, `docs.yml`, `publish.yml`, `release.yml`)
## Test plan
- [ ] CI workflow runs green on this PR