### PR TITLE
chore(pre-commit): widen ruff-format scope to Markdown, add ty hook

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,0 @@
-src/ant_ai/a2a/server.py:generic-api-key:3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,18 @@ repos:
                 - python
             args: [--fix]
           - id: ruff-format
+            types_or:
+                - python
+                - pyi
+                - jupyter
+                - markdown
 
     - repo: https://github.com/betterleaks/betterleaks
       rev: v1.8.1
       hooks:
           - id: betterleaks
+
+    - repo: https://github.com/astral-sh/ty-pre-commit
+      rev: v0.0.74
+      hooks:
+          - id: ty


### PR DESCRIPTION
## Summary
- PR #115's lint check failed in CI (`ruff format --check .`) over a Python code fence in `docs/docs/single-agent/streaming.md`, even though pre-commit had passed locally. Root cause: `ruff-format`'s pre-commit hook only matches `python`/`pyi`/`jupyter` files by default, while CI's repo-wide `ruff format --check .` also formats embedded Python code blocks in Markdown. Widens the hook's `types_or` to include `markdown` so this class of issue is caught locally instead of only in CI.
- Adds `ty` (astral-sh/ty-pre-commit) as a pre-commit hook so type errors surface locally as well, matching the `type-check` CI job.
- Removes a stale `.gitleaksignore` entry for `src/ant_ai/a2a/server.py:generic-api-key:3`.

## Test plan
- [x] `git commit` with the updated config ran `ruff-format` and the new `ty` hook locally, both passed
- [x] Confirmed reverting the earlier Markdown formatting fix and running `pre-commit run ruff-format --files <the .md file>` now flags it (previously silently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)